### PR TITLE
Add Dockerfile for frontend project

### DIFF
--- a/backend/src/routes.py
+++ b/backend/src/routes.py
@@ -6,7 +6,7 @@ def index():
     return "Hello world!"
 
 
-@app.route("/apitest")
+@app.route("/api/test")
 def apitest():
     res = {
         "content": "This is the content"

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:18 as build
+
+WORKDIR /app
+
+COPY . .
+
+RUN npm install
+RUN npm run build
+
+FROM nginxinc/nginx-unprivileged:1.25-alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+
+EXPOSE 8080
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/src/pages/LandingPage.jsx
+++ b/frontend/src/pages/LandingPage.jsx
@@ -6,7 +6,7 @@ export const LandingPage = () => {
 
     useEffect(() => {
         const getContent = async () => {
-            const res = await axios('http://localhost:5000/apitest')
+            const res = await axios('/api/test')
             setContent(res)
             setContent(res.data.content)
         }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -6,11 +6,14 @@ import react from '@vitejs/plugin-react'
 // https://vitejs.dev/config/
 export default defineConfig({
     plugins: [react()],
-    /* Proxy for development */
-    proxy: {
-        '/api': {
-            target: 'http://localhost:5000',
-            changeOrigin: true,
+    server: {
+        /* Proxy for development */
+        proxy: {
+            '/api': {
+                /* https://github.com/nodejs/node/issues/40537 */
+                target: 'http://127.0.0.1:5000',
+                changeOrigin: true,
+            }
         }
     }
 })

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,7 +1,16 @@
-import { defineConfig } from 'vite'
+import {
+    defineConfig
+} from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
 export default defineConfig({
     plugins: [react()],
+    /* Proxy for development */
+    proxy: {
+        '/api': {
+            target: 'http://localhost:5000',
+            changeOrigin: true,
+        }
+    }
 })


### PR DESCRIPTION
* Add dockerfile for frontend project. First build step builds the React app and in second we copy it into unprivileged NGINX container for the actual deployment.
* Configured Vite to proxy the requests to ``localhost:5173/api`` -> ``localhost:5000/api`` in the local development environment.

Closes #71 