### PR TITLE
Use npm ci in the Dockerfile

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 COPY . .
 
-RUN npm install
+RUN npm ci
 RUN npm run build
 
 FROM nginxinc/nginx-unprivileged:1.25-alpine


### PR DESCRIPTION
Use [``npm ci``](https://docs.npmjs.com/cli/v10/commands/npm-ci?v=true) instead of ``npm install`` in the frontend Dockerfile