### PR TITLE
Fix automatic redeployment for the staging environment

### DIFF
--- a/kubernetes/base/kustomization.yaml
+++ b/kubernetes/base/kustomization.yaml
@@ -4,10 +4,12 @@ resources:
   - backend/deployment.yaml
   - frontend/deployment.yaml
   - ingress.yaml
+# Add useful metadata to the resources
 buildMetadata: [managedByLabel, originAnnotations]
 commonLabels:
   app: ilmastokompassi
   app.kubernetes.io/part-of: ilmastokompassi
+# Add a prefix to all resource names
 namePrefix: ilmastokompassi-
 configMapGenerator:
   - name: ingress-nginx-conf

--- a/kubernetes/production/kustomization.yaml
+++ b/kubernetes/production/kustomization.yaml
@@ -3,10 +3,12 @@ kind: Kustomization
 resources:
   - ../base
 patches:
+  # Patch the ingress to use the production hostname
   - path: patch-ingress.yaml
     target:
       kind: Ingress
       name: ingress
+# Override the production container image tags to point to specific version.
 images:
   - name: ilmastokompassi/backend
     newName: docker.io/ilmastokompassi/backend

--- a/kubernetes/production/kustomization.yaml
+++ b/kubernetes/production/kustomization.yaml
@@ -12,7 +12,7 @@ patches:
 images:
   - name: ilmastokompassi/backend
     newName: docker.io/ilmastokompassi/backend
-    newTag: v0.0.1
+    newTag: 0.0.1
   - name: ilmastokompassi/frontend
     newName: docker.io/ilmastokompassi/frontend
-    newTag: v0.0.1
+    newTag: 0.0.1

--- a/kubernetes/staging/add-backend-imagestream-trigger.yaml
+++ b/kubernetes/staging/add-backend-imagestream-trigger.yaml
@@ -8,6 +8,10 @@
             "kind": "ImageStreamTag",
             "name": "ilmastokompassi-backend:latest"
           },
-          "fieldPath": "spec.template.spec.containers[?(@.name=='backend')].image"
+          "fieldPath": "spec.template.spec.containers[?(@.name==\"backend\")].image"
         }
       ]
+- op: add
+  path: "/spec/template/metadata/annotations"
+  value:
+    alpha.image.policy.openshift.io/resolve-names: "*"

--- a/kubernetes/staging/add-backend-imagestream-trigger.yaml
+++ b/kubernetes/staging/add-backend-imagestream-trigger.yaml
@@ -11,7 +11,3 @@
           "fieldPath": "spec.template.spec.containers[?(@.name==\"backend\")].image"
         }
       ]
-- op: add
-  path: "/spec/template/metadata/annotations"
-  value:
-    alpha.image.policy.openshift.io/resolve-names: "*"

--- a/kubernetes/staging/add-backend-imagestream-trigger.yaml
+++ b/kubernetes/staging/add-backend-imagestream-trigger.yaml
@@ -1,0 +1,13 @@
+- op: add
+  path: "/metadata/annotations"
+  value:
+    image.openshift.io/triggers: |-
+      [
+        {
+          "from": {
+            "kind": "ImageStreamTag",
+            "name": "ilmastokompassi-backend:latest"
+          },
+          "fieldPath": "spec.template.spec.containers[?(@.name=='backend')].image"
+        }
+      ]

--- a/kubernetes/staging/add-frontend-imagestream-trigger.yaml
+++ b/kubernetes/staging/add-frontend-imagestream-trigger.yaml
@@ -1,0 +1,13 @@
+- op: add
+  path: "/metadata/annotations"
+  value:
+    image.openshift.io/triggers: |-
+      [
+        {
+          "from": {
+            "kind": "ImageStreamTag",
+            "name": "ilmastokompassi-frontend:latest"
+          },
+          "fieldPath": "spec.template.spec.containers[?(@.name=='frontend')].image"
+        }
+      ]

--- a/kubernetes/staging/add-frontend-imagestream-trigger.yaml
+++ b/kubernetes/staging/add-frontend-imagestream-trigger.yaml
@@ -11,7 +11,3 @@
           "fieldPath": "spec.template.spec.containers[?(@.name==\"frontend\")].image"
         }
       ]
-- op: add
-  path: "/spec/template/metadata/annotations"
-  value:
-    alpha.image.policy.openshift.io/resolve-names: "*"

--- a/kubernetes/staging/add-frontend-imagestream-trigger.yaml
+++ b/kubernetes/staging/add-frontend-imagestream-trigger.yaml
@@ -8,6 +8,10 @@
             "kind": "ImageStreamTag",
             "name": "ilmastokompassi-frontend:latest"
           },
-          "fieldPath": "spec.template.spec.containers[?(@.name=='frontend')].image"
+          "fieldPath": "spec.template.spec.containers[?(@.name==\"frontend\")].image"
         }
       ]
+- op: add
+  path: "/spec/template/metadata/annotations"
+  value:
+    alpha.image.policy.openshift.io/resolve-names: "*"

--- a/kubernetes/staging/enable-imagestream-lookup.yaml
+++ b/kubernetes/staging/enable-imagestream-lookup.yaml
@@ -1,0 +1,4 @@
+- op: add
+  path: "/spec/template/metadata/annotations"
+  value:
+    alpha.image.policy.openshift.io/resolve-names: "*"

--- a/kubernetes/staging/imagestreams.yaml
+++ b/kubernetes/staging/imagestreams.yaml
@@ -1,0 +1,37 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: ilmastokompassi-backend
+  labels:
+    app: ilmastokompassi
+    app.kubernetes.io/part-of: ilmastokompassi
+spec:
+  tags:
+    - from:
+        kind: DockerImage
+        name: docker.io/ilmastokompassi/backend
+      name: latest
+      annotations:
+        app: ilmastokompassi
+        app.kubernetes.io/part-of: ilmastokompassi
+      importPolicy:
+        scheduled: true
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: ilmastokompassi-frontend
+  labels:
+    app: ilmastokompassi
+    app.kubernetes.io/part-of: ilmastokompassi
+spec:
+  tags:
+    - from:
+        kind: DockerImage
+        name: docker.io/ilmastokompassi/frontend
+      name: latest
+      annotations:
+        app: ilmastokompassi
+        app.kubernetes.io/part-of: ilmastokompassi
+      importPolicy:
+        scheduled: true

--- a/kubernetes/staging/imagestreams.yaml
+++ b/kubernetes/staging/imagestreams.yaml
@@ -6,10 +6,12 @@ metadata:
     app: ilmastokompassi
     app.kubernetes.io/part-of: ilmastokompassi
 spec:
+  lookupPolicy:
+    local: true
   tags:
     - from:
         kind: DockerImage
-        name: docker.io/ilmastokompassi/backend
+        name: docker.io/ilmastokompassi/backend:latest
       name: latest
       annotations:
         app: ilmastokompassi
@@ -25,10 +27,12 @@ metadata:
     app: ilmastokompassi
     app.kubernetes.io/part-of: ilmastokompassi
 spec:
+  lookupPolicy:
+    local: true
   tags:
     - from:
         kind: DockerImage
-        name: docker.io/ilmastokompassi/frontend
+        name: docker.io/ilmastokompassi/frontend:latest
       name: latest
       annotations:
         app: ilmastokompassi

--- a/kubernetes/staging/kustomization.yaml
+++ b/kubernetes/staging/kustomization.yaml
@@ -2,15 +2,22 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
+  - imagestreams.yaml
 patches:
   - path: patch-ingress.yaml
     target:
       kind: Ingress
       name: ingress
+  - path: add-backend-imagestream-trigger.yaml
+    target:
+      kind: Deployment
+      name: backend
+  - path: add-frontend-imagestream-trigger.yaml
+    target:
+      kind: Deployment
+      name: frontend
 images:
   - name: ilmastokompassi/backend
-    newName: docker.io/ilmastokompassi/backend
     newTag: latest
   - name: ilmastokompassi/frontend
-    newName: docker.io/ilmastokompassi/frontend
     newTag: latest

--- a/kubernetes/staging/kustomization.yaml
+++ b/kubernetes/staging/kustomization.yaml
@@ -4,10 +4,12 @@ resources:
   - ../base
   - imagestreams.yaml
 patches:
+  # Patch the ingress to use the staging hostname
   - path: patch-ingress.yaml
     target:
       kind: Ingress
       name: ingress
+  # Add OpenShit ImageStream triggers to update containers to point new images
   - path: add-backend-imagestream-trigger.yaml
     target:
       kind: Deployment
@@ -16,6 +18,11 @@ patches:
     target:
       kind: Deployment
       name: frontend
+  # Enable Kubernetes deployments to lookup OpenShift specific ImageStreamTags
+  - path: enable-imagestream-lookup.yaml
+    target:
+      kind: Deployment
+# Override the staging container images to use the OpenShift ImageStreamTags
 images:
   - name: ilmastokompassi/backend
     newName: ilmastokompassi-backend

--- a/kubernetes/staging/kustomization.yaml
+++ b/kubernetes/staging/kustomization.yaml
@@ -18,6 +18,8 @@ patches:
       name: frontend
 images:
   - name: ilmastokompassi/backend
+    newName: ilmastokompassi-backend
     newTag: latest
   - name: ilmastokompassi/frontend
+    newName: ilmastokompassi-frontend
     newTag: latest


### PR DESCRIPTION
This PR adds OpenShift specific configuration for the staging environment to automatically redeploy the containers with new images, when a new image tagged with `latest` is pushed to the Docker Hub.