### PR TITLE
Update workflow_guide.md

### DIFF
--- a/documentation/workflow_guide.md
+++ b/documentation/workflow_guide.md
@@ -8,42 +8,45 @@
   
 ### Run
 * Open two terminals
-    * Move to /backend: `poetry install`, `poetry shell`, `invoke dev`
+    * Move to /backend: `poetry install`, `poetry run invoke dev`
     * Move to /frontend: `npm install`, `npm run dev`,  ctrl + click to open site
   
 ### Completing a task
-* Choose a task from the sprint backlog, assign yourself to the task and set task status to _In progress_
-* Create a new branch `git switch -c <feature-YourBranch>`
-* Write the code
-* Run your code with `invoke dev`
+* Choose a task from the sprint backlog, assign yourself to the t
+* ask and set task status to _In progress_
+* Create a new branch `git switch -c <branch-name>`
+* See [Run](#run)-section how to run application locally
+* Write and debug the code
 * Write tests
-* Run tests and debug until 100 % approval rate: `invoke test`, for coverage: `invoke coverage` and `invoke coverage-report`
-* jest tests: `npm test`
-* To run Cypress tests open 3 terminals:
-    - backend: `poetry shell`, `invoke dev`
+* Run backend tests: `poetry run invoke test`.
+  * Check coverage: `poetry run invoke coverage`
+  * Generate report: `poetry run invoke coverage-report`
+* Run frontend tests: `npm test`
+* Run end-to-end (e2e) cypress tests, open 3 terminals:
+    - backend: `poetry run invoke dev`
     - frontend: `npm run dev`
     - frontend: `npm run cypress:open` or headless: `npm run cypress:headless`
 * Run lint
     - backend: `invoke lint`
     - frontend: `npm run lint`
-* Commiting: add and commit changed files. Add to a commit message `[skip ci]`, to avoid running unneeded tests. Push always to your own branch: `git push -u origin <feature-YourBranch>`
-* Create a pull request in GitHub. 
-* Post a short message in Discord about new pull request requiring to be approved and merged. Include a short description of added functionalities and/or bug fixes and if the branch can be closed after approval.
+* Commiting: add and commit changed files.
+  * Try to avoid big commits. Keep them focused and small, if possible.
+* Push commits to your own branch: `git push -u origin <branch-name>`
+* Create a pull request in GitHub.
+  * Include a short description of added functionalities and/or bug fixes.
 * After the pull request is approved mark the task status as 'Done' in the sprint backlog
 
-### Approving a pull request
-* Check Discord or GitHub for pull requests waiting for approval. Note: code submitter can't handle their own pull requests.
-* Go to Github and choose the pull request you want to handle
-* Click "Files changed"
-* Read the code and review changes/additions
-* Check CI test results
-* Handling the pull request:
-   * Decline the request if there is any conflicts or others issues
-   * Approve if no issues/conflicts
+### Reviewing a pull request
+* Check Discord or GitHub for pull requests waiting for approval.
+  * Note: code submitter can't approve their own pull requests.
+* Open the Pull request on GitHub and review the added/modified files
+  * On "Commits" tab you can see changes by individual commits
+  * On "Files changed" you can see changes by individual files
+* Check CI test results.
+* Approve and merge, if there is no issues/conflicts. 
 
 ### When your workday is over
 * Update sprint backlog if needed
 * Add your daily hours to Clockify
-
 
 *[Workflow guide](https://github.com/piryopt/pienryhmien-optimointi/blob/main/documentation/workflow_guide.md) was used for inspiration in creating this guide.*

--- a/documentation/workflow_guide.md
+++ b/documentation/workflow_guide.md
@@ -12,8 +12,7 @@
     * Move to /frontend: `npm install`, `npm run dev`,  ctrl + click to open site
   
 ### Completing a task
-* Choose a task from the sprint backlog, assign yourself to the t
-* ask and set task status to _In progress_
+* Choose a task from the sprint backlog, assign yourself to the task and set task status to _In progress_
 * Create a new branch `git switch -c <branch-name>`
 * See [Run](#run)-section how to run application locally
 * Write and debug the code


### PR DESCRIPTION
Reword and restructure parts of the workflow documentation. Still a bit too complex, which I hope to solve later with #157 .

* Make peotry commands not depend on the poetry shell environment.
* Remove `[skip ci]`. It shouldn't be used anymore, the GitHub actions checks whether the commits/pr touches actual application code or not.