### PR TITLE
Configure backend for database deployment

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.10-buster as builder
 
+RUN apt-get update && \
+    apt-get install -y libpq-dev gcc
+
 RUN pip install poetry==1.6.1
 
 ENV POETRY_NO_INTERACTION=1 \
@@ -14,6 +17,9 @@ COPY pyproject.toml poetry.lock ./
 RUN poetry install --without dev --no-root && rm -rf $POETRY_CACHE_DIR
 
 FROM python:3.10-slim-buster as runtime
+
+RUN apt-get update && \
+    apt-get install -y libpq-dev gcc
 
 ENV VIRTUAL_ENV=/app/.venv \
     PATH="/app/.venv/bin:$PATH"

--- a/kubernetes/base/backend/deployment.yaml
+++ b/kubernetes/base/backend/deployment.yaml
@@ -29,6 +29,17 @@ spec:
             limits:
               cpu: 100m
               memory: 300Mi
+          env:
+            - name: DATABASE_URI
+              valueFrom:
+                secretKeyRef:
+                  name: ilmastokompassi-backend-config
+                  key: DATABASE_URI
+            - name: SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: ilmastokompassi-backend-config
+                  key: SECRET_KEY
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
* Configure environment variables for the `backend` container pods from `Secret` object.
* Add `libpq-dev` to backend Dockerfile

Secrets are now deployed to staging and production environment.

Closes #132 
Contributes to #164 