### PR TITLE
Use latest debian in backend Dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,7 +1,4 @@
-FROM python:3.10-buster as builder
-
-RUN apt-get update && \
-    apt-get install -y libpq-dev gcc
+FROM python:3.10-bookworm as builder
 
 RUN pip install poetry==1.6.1
 
@@ -16,10 +13,11 @@ COPY pyproject.toml poetry.lock ./
 
 RUN poetry install --without dev --no-root && rm -rf $POETRY_CACHE_DIR
 
-FROM python:3.10-slim-buster as runtime
+FROM python:3.10-slim-bookworm as runtime
 
 RUN apt-get update && \
     apt-get install -y libpq-dev gcc
+
 
 ENV VIRTUAL_ENV=/app/.venv \
     PATH="/app/.venv/bin:$PATH"

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -18,7 +18,6 @@ FROM python:3.10-slim-bookworm as runtime
 RUN apt-get update && \
     apt-get install -y libpq-dev gcc
 
-
 ENV VIRTUAL_ENV=/app/.venv \
     PATH="/app/.venv/bin:$PATH"
 


### PR DESCRIPTION
* Use latest bookworm in the backend Dockerfile in both builder and runtime stages