### PR TITLE
Create new group

### DIFF
--- a/backend/src/repositories/group_repository.py
+++ b/backend/src/repositories/group_repository.py
@@ -3,7 +3,7 @@ from src.extensions import db
 
 class GroupRepository:
     # pylint: disable=too-few-public-methods
-    
+
     def save_group(self, token):
         try:
             sql = text("INSERT INTO groups (token) VALUES (:token)")
@@ -11,8 +11,7 @@ class GroupRepository:
         except Exception as error: # pylint: disable=broad-except
             db.session.rollback()
             raise error
-        
-        db.session.commit()
-        
-default_group_repository = GroupRepository()
 
+        db.session.commit()
+
+default_group_repository = GroupRepository()

--- a/backend/src/repositories/group_repository.py
+++ b/backend/src/repositories/group_repository.py
@@ -1,0 +1,18 @@
+from sqlalchemy import text
+from src.extensions import db
+
+class GroupRepository:
+    # pylint: disable=too-few-public-methods
+    
+    def save_group(self, token):
+        try:
+            sql = text("INSERT INTO groups (token) VALUES (:token)")
+            db.session.execute(sql, {"token": token})
+        except Exception as error: # pylint: disable=broad-except
+            db.session.rollback()
+            raise error
+        
+        db.session.commit()
+        
+default_group_repository = GroupRepository()
+

--- a/backend/src/routes.py
+++ b/backend/src/routes.py
@@ -1,6 +1,7 @@
 from flask import jsonify, abort, request, current_app as app
 from src.services.profile_service import default_profile_service
 from src.services.survey_service import default_survey_service
+from src.services.group_service import default_group_service
 
 
 @app.route("/")
@@ -54,5 +55,18 @@ def get_summary(user_id):
             user_id)
         return jsonify(count=count, summary=summary, total_questions_count=total_questions_count)
     except Exception as error:  # pylint: disable=broad-except
+        print(error)
+        return jsonify(error="Something went wrong!"), 500
+    
+@app.route('/api/new-group', methods=['POST'])
+def new_group():
+    data = request.get_json()
+    token = data.get('token')
+    try:
+        group_token = default_group_service.save_group(token)
+        return jsonify({"status": "success",
+                        "message": "Group created successfully",
+                        "group_token": group_token}), 200
+    except Exception as error:
         print(error)
         return jsonify(error="Something went wrong!"), 500

--- a/backend/src/routes.py
+++ b/backend/src/routes.py
@@ -57,7 +57,7 @@ def get_summary(user_id):
     except Exception as error:  # pylint: disable=broad-except
         print(error)
         return jsonify(error="Something went wrong!"), 500
-    
+
 @app.route('/api/new-group', methods=['POST'])
 def new_group():
     data = request.get_json()
@@ -67,6 +67,7 @@ def new_group():
         return jsonify({"status": "success",
                         "message": "Group created successfully",
                         "group_token": group_token}), 200
-    except Exception as error:
+    except Exception as error: #pylint: disable=broad-except
         print(error)
         return jsonify(error="Something went wrong!"), 500
+    

--- a/backend/src/services/group_service.py
+++ b/backend/src/services/group_service.py
@@ -2,16 +2,16 @@ from src.repositories.group_repository import default_group_repository
 
 class GroupService:
     # pylint: disable=too-few-public-methods
-    
+
     def __init__(self, group_repository=default_group_repository):
         self.group_repository = group_repository
-        
+
     def save_group(self, token):
         try:
             self.group_repository.save_group(token)
         except Exception as error: # pylint: disable=broad-except
             raise error
-        
+
         return token
-    
+
 default_group_service = GroupService(default_group_repository)

--- a/backend/src/services/group_service.py
+++ b/backend/src/services/group_service.py
@@ -1,0 +1,17 @@
+from src.repositories.group_repository import default_group_repository
+
+class GroupService:
+    # pylint: disable=too-few-public-methods
+    
+    def __init__(self, group_repository=default_group_repository):
+        self.group_repository = group_repository
+        
+    def save_group(self, token):
+        try:
+            self.group_repository.save_group(token)
+        except Exception as error: # pylint: disable=broad-except
+            raise error
+        
+        return token
+    
+default_group_service = GroupService(default_group_repository)

--- a/frontend/src/components/GroupDialog.jsx
+++ b/frontend/src/components/GroupDialog.jsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { useNavigate } from 'react-router-dom'
 import {
     Dialog,
     DialogTitle,
@@ -12,14 +13,27 @@ import {
 export default function GroupDialog() {
     const [groupName, setGroupName] = React.useState('')
     const [open, setOpen] = React.useState(false)
+    const navigate = useNavigate()
 
     const handleGroupNameChange = (event) => {
         setGroupName(event.target.value)
     }
 
     const handleSubmit = () => {
-        // Call function to submit group name to database with 'token' as its name
-        console.log(`Submitting group name: ${groupName}`)
+        fetch('/api/new-group', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ token: groupName }),
+        })
+            .then((response) => response.json())
+            .then(() => {
+                setOpen(false)
+                window.alert('Ryhmä luotu onnistuneesti!')
+                navigate('/survey/')
+            })
+            .catch((error) => console.error(error))
     }
 
     return (

--- a/frontend/src/components/GroupDialog.jsx
+++ b/frontend/src/components/GroupDialog.jsx
@@ -1,0 +1,61 @@
+import * as React from 'react'
+import {
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    DialogContentText,
+    DialogActions,
+    TextField,
+    Button,
+} from '@mui/material'
+
+export default function GroupDialog() {
+    const [groupName, setGroupName] = React.useState('')
+    const [open, setOpen] = React.useState(false)
+
+    const handleGroupNameChange = (event) => {
+        setGroupName(event.target.value)
+    }
+
+    const handleSubmit = () => {
+        // Call function to submit group name to database with 'token' as its name
+        console.log(`Submitting group name: ${groupName}`)
+    }
+
+    return (
+        <div>
+            <Button
+                variant="outlined"
+                color="primary"
+                onClick={() => setOpen(true)}
+            >
+                Luo ryhmä
+            </Button>
+            <Dialog open={open} onClose={() => setOpen(false)}>
+                <DialogTitle>Luo uusi ryhmä</DialogTitle>
+                <DialogContent>
+                    <DialogContentText>
+                        Syötä haluamasi uuden ryhmän tunnus ja paina
+                        &quot;Luo&quot;.
+                    </DialogContentText>
+                    <TextField
+                        autoFocus
+                        margin="dense"
+                        label="Ryhmän tunnus"
+                        type="text"
+                        fullWidth
+                        variant="standard"
+                        value={groupName}
+                        onChange={handleGroupNameChange}
+                    />
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={() => setOpen(false)}>Peruuta</Button>
+                    <Button onClick={handleSubmit} color="primary">
+                        Luo
+                    </Button>
+                </DialogActions>
+            </Dialog>
+        </div>
+    )
+}

--- a/frontend/src/pages/SurveyPage.jsx
+++ b/frontend/src/pages/SurveyPage.jsx
@@ -3,6 +3,7 @@ import { NavLink } from 'react-router-dom'
 import styled from '@emotion/styled'
 import { useEffect } from 'react'
 import FormDialog from '../components/FormDialog'
+import GroupDialog from '../components/GroupDialog'
 
 const SurveyOptionButton = styled(Button)`
     /* Add your styling here */
@@ -51,10 +52,8 @@ export function SurveyPage() {
                         </Typography>
                     </SurveyOptionButton>
                 </Stack>
-                <Box>
-                    <Button variant="text" size="small">
-                        Luo ryhmä
-                    </Button>
+                <Box alignSelf="center">
+                    <GroupDialog />
                 </Box>
             </Stack>
         </SurveyPageContainer>


### PR DESCRIPTION
This pull request adds new `GroupDialog` component that handles creating new group. We have also added `GroupRepository`, `GroupService` and routing to make all this handling possible.

Submission validation and restrictions are not handled, these needs have been mentioned in issue #231.

Contributes to #229 and #231 