### PR TITLE
Group name is saved in uppercase and user sees name written in uppercase

### DIFF
--- a/frontend/src/components/GroupDialog.jsx
+++ b/frontend/src/components/GroupDialog.jsx
@@ -16,7 +16,7 @@ export default function GroupDialog() {
     const navigate = useNavigate()
 
     const handleGroupNameChange = (event) => {
-        setGroupName(event.target.value)
+        setGroupName(event.target.value.toUpperCase())
     }
 
     const handleSubmit = () => {
@@ -25,7 +25,7 @@ export default function GroupDialog() {
             headers: {
                 'Content-Type': 'application/json',
             },
-            body: JSON.stringify({ token: groupName }),
+            body: JSON.stringify({ token: groupName.toUpperCase() }),
         })
             .then((response) => response.json())
             .then(() => {


### PR DESCRIPTION
While user writes group session id they see it in uppercase in dialog window and group session id will be also saved to database in uppercase.

Contributes to #231 