### PR TITLE
Validate group 

### DIFF
--- a/backend/src/routes.py
+++ b/backend/src/routes.py
@@ -64,10 +64,18 @@ def new_group():
     data = request.get_json()
     token = data.get('token')
     try:
-        group_token = default_group_service.save_group(token)
-        return jsonify({"status": "success",
-                        "message": "Group created successfully",
-                        "group_token": group_token}), 200
+        if default_group_service.is_group_name_valid(token):
+            if not default_group_service.check_if_group_exists(token):
+                group_token = default_group_service.save_group(token)
+                return jsonify({"status": "success",
+                                "message": "Group created successfully",
+                                "group_token": group_token}), 200
+            else:
+                return jsonify({"status": "fail",
+                                "message": "Group already exists"}), 400
+        else:
+            return jsonify({"status": "fail",
+                            "message": "Invalid group name"}), 400
     except Exception as error:  # pylint: disable=broad-except
         print(error)
         return jsonify(error="Something went wrong!"), 500

--- a/backend/src/routes.py
+++ b/backend/src/routes.py
@@ -70,11 +70,9 @@ def new_group():
                 return jsonify({"status": "success",
                                 "message": "Group created successfully",
                                 "group_token": group_token}), 200
-            else:
-                return jsonify({"status": "fail",
-                                "message": "Group already exists"}), 400
-        else:
             return jsonify({"status": "fail",
+                                "message": "Group already exists"}), 400
+        return jsonify({"status": "fail",
                             "message": "Invalid group name"}), 400
     except Exception as error:  # pylint: disable=broad-except
         print(error)

--- a/backend/src/services/group_service.py
+++ b/backend/src/services/group_service.py
@@ -21,6 +21,16 @@ class GroupService:
             return result
         except Exception as error:
             raise error
-
+    
+    def is_group_name_valid(self, token):
+        if token == '':
+            return False
+        elif len(token) > 10:
+            return False
+        elif not token.isupper() and not token.isdigit():
+            return False
+        else:
+            return True
+        
 
 default_group_service = GroupService(default_group_repository)

--- a/backend/src/services/group_service.py
+++ b/backend/src/services/group_service.py
@@ -21,16 +21,15 @@ class GroupService:
             return result
         except Exception as error:
             raise error
-    
+
     def is_group_name_valid(self, token):
         if token == '':
             return False
-        elif len(token) > 10:
+        if len(token) > 10:
             return False
-        elif not token.isupper() and not token.isdigit():
+        if not token.isupper() and not token.isdigit():
             return False
-        else:
-            return True
-        
+        return True
+
 
 default_group_service = GroupService(default_group_repository)

--- a/backend/src/tests/test_group_service.py
+++ b/backend/src/tests/test_group_service.py
@@ -1,0 +1,30 @@
+import unittest
+from unittest.mock import MagicMock
+from src.services.group_service import GroupService
+
+
+class TestGroupService(unittest.TestCase):
+    def setUp(self):
+        self.mock_group_repository = MagicMock()
+        self.group_service = GroupService(self.mock_group_repository)
+
+    def test_save_group(self):
+        token = "test_token"
+        self.group_service.save_group(token)
+        self.mock_group_repository.save_group.assert_called_once_with(token)
+
+    def test_check_if_group_exists(self):
+        token = "test_token"
+        self.group_service.check_if_group_exists(token)
+        self.mock_group_repository.check_if_group_exists.assert_called_once_with(token)
+
+    def test_is_group_name_valid(self):
+        self.assertTrue(self.group_service.is_group_name_valid("TEST1234"))
+        self.assertTrue(self.group_service.is_group_name_valid("1234567890"))
+        self.assertFalse(self.group_service.is_group_name_valid(""))
+        self.assertFalse(self.group_service.is_group_name_valid("test"))
+        self.assertFalse(self.group_service.is_group_name_valid("test123456789"))
+
+if __name__ == '__main__':
+    unittest.main()
+    

--- a/frontend/src/components/GroupDialog.jsx
+++ b/frontend/src/components/GroupDialog.jsx
@@ -20,6 +20,18 @@ export default function GroupDialog() {
     }
 
     const handleSubmit = () => {
+        if (groupName === '') {
+            window.alert('Ryhmän tunnus ei voi olla tyhjä merkkijono.')
+            return
+        } else if (groupName.length > 10) {
+            window.alert('Ryhmän tunnus ei voi olla yli 10 merkkiä pitkä.')
+            return
+        } else if (!/^[A-Z0-9]+$/.test(groupName)) {
+            window.alert(
+                'Ryhmän tunnus voi sisältää vain isoja kirjaimia ja numeroita.'
+            )
+            return
+        }
         fetch('/api/new-group', {
             method: 'POST',
             headers: {

--- a/frontend/src/components/GroupDialog.jsx
+++ b/frontend/src/components/GroupDialog.jsx
@@ -61,8 +61,10 @@ export default function GroupDialog() {
                 <DialogTitle>Luo uusi ryhmä</DialogTitle>
                 <DialogContent>
                     <DialogContentText>
-                        Syötä haluamasi uuden ryhmän tunnus ja paina
-                        &quot;Luo&quot;.
+                        Ryhmän tunnus voi sisältää vain isoja kirjaimia,
+                        numeroita tai niiden yhdistelmiä. Ryhmän tunnus saa olla
+                        enintään 10 merkkiä pitkä. Syötä haluamasi uuden ryhmän
+                        tunnus ja paina &quot;Luo&quot;.
                     </DialogContentText>
                     <TextField
                         autoFocus


### PR DESCRIPTION
Frontend and backend group name (token) validations added. There is preliminary tests for backend validation, no frontend tests implemented yet.

Known issue that needs to be fixed later: Frontend doesn't inform user, if group name (token) already exists in the database. Group name (token) should be unique.

Contributes to #232 and #232 