### PR TITLE
Update labeler actions workflow

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,6 +1,5 @@
 "ci/cd":
   - .github/**/*
-  - kubernetes/**/*
 
 "frontend":
   - frontend/**/*
@@ -9,11 +8,11 @@
   - backend/**/*
 
 "tests":
-  - "**/tests/**/*"
+  - **/tests/**/*
 
 "k8s":
   - kubernetes/**/*
 
-"documentation":
+"docs":
   - documentation/**/*
   - README.md


### PR DESCRIPTION
- Shortened one of the labels a bit
- Removed `ci/cd` label from k8s, 'twas technically incorrect.