### PR TITLE
Moving Card -component to whole SummaryPage content

### DIFF
--- a/frontend/src/components/SummaryProfile.jsx
+++ b/frontend/src/components/SummaryProfile.jsx
@@ -1,11 +1,4 @@
-import {
-    Typography,
-    Box,
-    Card,
-    CardContent,
-    CardHeader,
-    Stack,
-} from '@mui/material'
+import { Typography, Box, CardContent, CardHeader, Stack } from '@mui/material'
 import PropTypes from 'prop-types'
 import ProfileImage from './ProfileImage'
 
@@ -25,43 +18,41 @@ export const SummaryProfile = ({ title, description }) => {
                     <ProfileImage title={title} />
                 </Stack>
             </Box>
-            <Card variant="outlined" sx={{ width: '100%' }}>
-                <Box
-                    sx={{
-                        display: 'flex',
-                        flexDirection: 'column',
-                        overflowWrap: 'break-word',
+            <Box
+                sx={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    overflowWrap: 'break-word',
+                }}
+            >
+                <CardHeader
+                    sx={{ textAlign: 'center' }}
+                    titleTypographyProps={{
+                        variant: 'h2',
+                        fontSize: {
+                            xs: '1.5em',
+                            sm: '1.75em',
+                            md: '2em',
+                        },
                     }}
-                >
-                    <CardHeader
-                        sx={{ textAlign: 'center' }}
-                        titleTypographyProps={{
-                            variant: 'h2',
+                    title={title}
+                ></CardHeader>
+                <CardContent sx={{ flex: '1 0 auto' }}>
+                    <Typography
+                        variant="h3"
+                        sx={{
                             fontSize: {
-                                xs: '1.5em',
-                                sm: '1.75em',
-                                md: '2em',
+                                xs: '0.9em',
+                                sm: '1em',
+                                md: '1.1em',
                             },
+                            p: '10px',
                         }}
-                        title={title}
-                    ></CardHeader>
-                    <CardContent sx={{ flex: '1 0 auto' }}>
-                        <Typography
-                            variant="h3"
-                            sx={{
-                                fontSize: {
-                                    xs: '0.9em',
-                                    sm: '1em',
-                                    md: '1.1em',
-                                },
-                                p: '10px',
-                            }}
-                        >
-                            {description}
-                        </Typography>
-                    </CardContent>
-                </Box>
-            </Card>
+                    >
+                        {description}
+                    </Typography>
+                </CardContent>
+            </Box>
         </>
     )
 }

--- a/frontend/src/pages/SummaryPage.jsx
+++ b/frontend/src/pages/SummaryPage.jsx
@@ -1,10 +1,9 @@
 import useSWR from 'swr'
 import { SummaryProfile } from '../components/SummaryProfile'
-import { Typography, Container, Stack, Button, Box } from '@mui/material'
+import { Typography, Container, Stack, Button, Box, Card } from '@mui/material'
 import { useParams } from 'react-router-dom'
 import { useTitle } from '../hooks/useTitle'
 import SummaryDoughnut from '../components/SummaryDoughnut'
-
 
 export const SummaryPage = () => {
     const { userId: userParamId } = useParams()
@@ -56,68 +55,81 @@ export const SummaryPage = () => {
     useTitle('Ilmastoprofiili - Tulokset')
     return (
         <Container>
-            <Stack
-                spacing={4}
-                paddingTop={'30px'}
-                paddingBottom={'50px'}
-                alignItems={'center'}
-            >
-                <Typography
-                    variant="h1"
-                    sx={{
-                        fontSize: {
-                            xs: '2em', // Smaller font size for extra small screens
-                            sm: '3em', // Slightly bigger for small screens
-                            md: '4em', // Original size for medium screens and up
-                        },
-                        textAlign: 'center',
-                        p: '20px',
-                    }}
-                >
-                    Oma ilmastoprofiilisi
-                </Typography>
-                {isLoadingProfiles || isLoadingSummary ? (
-                    <p>Loading...</p>
-                ) : answerCount > 0 ? (
-                    <>
+            <Box paddingY={5}>
+                <Card>
+                    <Stack
+                        spacing={4}
+                        paddingTop={'30px'}
+                        paddingBottom={'50px'}
+                        alignItems={'center'}
+                    >
                         <Typography
-                            variant="h2"
+                            variant="h1"
                             sx={{
                                 fontSize: {
-                                    xs: '1.5em',
-                                    sm: '1.75em',
-                                    md: '2em',
+                                    xs: '2em', // Smaller font size for extra small screens
+                                    sm: '3em', // Slightly bigger for small screens
+                                    md: '4em', // Original size for medium screens and up
                                 },
                                 textAlign: 'center',
-                                p: '10px',
+                                p: '20px',
                             }}
                         >
-                            Olet vastannut {answerCount}/{totalQuestions}{' '}
-                            kysymykseen ja alta löydät oman ilmastoprofiilisi!
+                            Oma ilmastoprofiilisi
                         </Typography>
+                        {isLoadingProfiles || isLoadingSummary ? (
+                            <p>Loading...</p>
+                        ) : answerCount > 0 ? (
+                            <>
+                                <Typography
+                                    variant="h2"
+                                    sx={{
+                                        fontSize: {
+                                            xs: '1.5em',
+                                            sm: '1.75em',
+                                            md: '2em',
+                                        },
+                                        textAlign: 'center',
+                                        p: '10px',
+                                    }}
+                                >
+                                    Olet vastannut {answerCount}/
+                                    {totalQuestions} kysymykseen ja alta löydät
+                                    oman ilmastoprofiilisi!
+                                </Typography>
 
-                        <SummaryProfile
-                            title={topProfileResult.name}
-                            description={topProfileResult.description}
-                        />
-                        <Box width={{ xs: '100vw', sm: '100vw', md: '30vw' }}>
-                            <SummaryDoughnut data={pieChartData} />
-                        </Box>
-                    </>
-                ) : (
-                    <>
-                        <Typography>Et ole vielä vastannut kyselyyn</Typography>
-                        <Button
-                            variant="contained"
-                            color="primary"
-                            aria-label="move to survey"
-                            href={`/survey`}
-                        >
-                            Siirry tästä kyselyyn!
-                        </Button>
-                    </>
-                )}
-            </Stack>
+                                <SummaryProfile
+                                    title={topProfileResult.name}
+                                    description={topProfileResult.description}
+                                />
+                                <Box
+                                    width={{
+                                        xs: '100vw',
+                                        sm: '100vw',
+                                        md: '30vw',
+                                    }}
+                                >
+                                    <SummaryDoughnut data={pieChartData} />
+                                </Box>
+                            </>
+                        ) : (
+                            <>
+                                <Typography>
+                                    Et ole vielä vastannut kyselyyn
+                                </Typography>
+                                <Button
+                                    variant="contained"
+                                    color="primary"
+                                    aria-label="move to survey"
+                                    href={`/survey`}
+                                >
+                                    Siirry tästä kyselyyn!
+                                </Button>
+                            </>
+                        )}
+                    </Stack>
+                </Card>
+            </Box>
         </Container>
     )
 }


### PR DESCRIPTION
All content on `SummaryPage` is inside a single Card -component, all text is now visible on white background