### PR TITLE
Fix path reference to '/tietovisa/ from '/quiztest/'

### DIFF
--- a/frontend/src/pages/FactQuizQuestionPage.jsx
+++ b/frontend/src/pages/FactQuizQuestionPage.jsx
@@ -113,7 +113,7 @@ export const FactQuizQuestionPage = () => {
                         )}
                         <IconButton
                             aria-label="next question"
-                            href={`/quiztest/${questionId + 1}`}
+                            href={`/tietovisa/${questionId + 1}`}
                             disabled={
                                 !totalQuestions || questionId >= totalQuestions
                             }


### PR DESCRIPTION
`FactQuizQuestionPage.jsx` had reference to `/quiztest/`, changing it to `/tietovisa/`