### PR TITLE
Restructured how the fact quiz works

### DIFF
--- a/backend/src/repositories/quiz_repository.py
+++ b/backend/src/repositories/quiz_repository.py
@@ -10,7 +10,8 @@ class QuizRepository:
         questions = [dict(row) for row in result]
         return questions
 
-    # Response id should only be created once when the user starts the quiz, code below needs to be completely restructured
+    # Response id should only be created once when the user starts the quiz,
+    # code below needs to be completely restructured
 
     def save_answers(self, answers, group_token=None):
         try:

--- a/backend/src/repositories/quiz_repository.py
+++ b/backend/src/repositories/quiz_repository.py
@@ -10,6 +10,8 @@ class QuizRepository:
         questions = [dict(row) for row in result]
         return questions
 
+    # Response id should only be created once when the user starts the quiz, code below needs to be completely restructured
+
     def save_answers(self, answers, group_token=None):
         try:
             with db.session.begin_nested():

--- a/frontend/cypress/e2e/survey.spec.cy.js
+++ b/frontend/cypress/e2e/survey.spec.cy.js
@@ -18,6 +18,8 @@ describe('From survey page large ', function () {
 
         cy.title().should('eq', 'Ilmastoprofiili - Tulokset')
         cy.contains('33/33')
-        cy.contains('Sinä haet kompromisseja eettisen kuluttajan tiellä.')
+        cy.contains(
+            'Maailma muuttuu ja sinussa on ainesta johtamaan tätä muutosta.'
+        )
     })
 })

--- a/frontend/src/components/QuestionCard.jsx
+++ b/frontend/src/components/QuestionCard.jsx
@@ -13,7 +13,7 @@ function QuestionCard({
     selectedOptionsIds,
     onOptionSelected,
     alwaysCol,
-    canAnswer,
+    canAnswer = true,
 }) {
     const cardStyles = {
         width: '80%',

--- a/frontend/src/components/QuestionCard.jsx
+++ b/frontend/src/components/QuestionCard.jsx
@@ -13,6 +13,7 @@ function QuestionCard({
     selectedOptionsIds,
     onOptionSelected,
     alwaysCol,
+    canAnswer,
 }) {
     const cardStyles = {
         width: '80%',
@@ -64,6 +65,7 @@ function QuestionCard({
                                     : 'outlined'
                             }
                             onClick={() => onOptionSelected(option.id)}
+                            disabled={!canAnswer}
                         >
                             {option.name}
                         </Button>
@@ -85,6 +87,7 @@ QuestionCard.propTypes = {
     selectedOptionsIds: PropTypes.object,
     onOptionSelected: PropTypes.func,
     alwaysCol: PropTypes.bool,
+    canAnswer: PropTypes.bool,
 }
 
 export default QuestionCard

--- a/frontend/src/pages/FactQuizQuestionPage.jsx
+++ b/frontend/src/pages/FactQuizQuestionPage.jsx
@@ -58,21 +58,21 @@ export const FactQuizQuestionPage = () => {
     const handleAnswer = async () => {
         console.log(Array.from(selectedOptionsIds))
         setHasAnswered(true)
-        try {
-            const response = await fetch('/api/quiz', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({
-                    questionId,
-                    selectedOptionsIds: Array.from(selectedOptionsIds),
-                }),
-            })
-            const data = await response.json()
-        } catch (error) {
-            console.log(error)
-        }
+        // try {
+        //     const response = await fetch('/api/quiz', {
+        //         method: 'POST',
+        //         headers: {
+        //             'Content-Type': 'application/json',
+        //         },
+        //         body: JSON.stringify({
+        //             questionId,
+        //             selectedOptionsIds: Array.from(selectedOptionsIds),
+        //         }),
+        //     })
+        //     const data = await response.json()
+        // } catch (error) {
+        //     console.log(error)
+        // }
     }
 
     const onOptionSelected = (optionId) => {

--- a/frontend/src/pages/FactQuizQuestionPage.jsx
+++ b/frontend/src/pages/FactQuizQuestionPage.jsx
@@ -1,13 +1,13 @@
 import { useState } from 'react'
 import { useParams } from 'react-router-dom'
-import { Button, IconButton, Stack, Typography } from '@mui/material'
-import ArrowCircleRightIcon from '@mui/icons-material/ArrowCircleRight'
+import { Button, Stack, Typography } from '@mui/material'
 import QuestionCard from '../components/QuestionCard'
 import { useTitle } from '../hooks/useTitle'
 
 export const FactQuizQuestionPage = () => {
     const { questionId: questionParamId } = useParams()
     const [selectedOptionsIds, setSelectedOptionsIds] = useState(new Set())
+    const [hasAnswered, setHasAnswered] = useState(false)
 
     // const { data: allQuestions, isLoading: isLoadingAllQuestions } =
     // useSWR('/api/quiz')
@@ -55,8 +55,24 @@ export const FactQuizQuestionPage = () => {
     const totalQuestions = allQuestions?.length
     const isLastQuestion = questionId == totalQuestions
 
-    const handleSubmit = () => {
-        console.log(selectedOptionsIds)
+    const handleAnswer = async () => {
+        console.log(Array.from(selectedOptionsIds))
+        setHasAnswered(true)
+        try {
+            const response = await fetch('/api/quiz', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    questionId,
+                    selectedOptionsIds: Array.from(selectedOptionsIds),
+                }),
+            })
+            const data = await response.json()
+        } catch (error) {
+            console.log(error)
+        }
     }
 
     const onOptionSelected = (optionId) => {
@@ -90,19 +106,43 @@ export const FactQuizQuestionPage = () => {
                         selectedOptionsIds={selectedOptionsIds}
                         onOptionSelected={onOptionSelected}
                         alwaysCol={true}
+                        canAnswer={!hasAnswered}
                     />
                     {/* Buttons */}
                     <Stack
-                        direction="row"
+                        direction="column"
                         justifyContent="space-evenly"
                         alignItems="center"
                         spacing={4}
                     >
-                        {isLastQuestion ? (
+                        {!hasAnswered && (
                             <Button
                                 variant="contained"
-                                color="secondary"
-                                onClick={handleSubmit}
+                                color="primary"
+                                onClick={handleAnswer}
+                                disabled={selectedOptionsIds.size === 0}
+                            >
+                                Vastaa
+                            </Button>
+                        )}
+                        {hasAnswered && !isLastQuestion && (
+                            <Button
+                                variant="contained"
+                                color="primary"
+                                href={`/tietovisa/${questionId + 1}`}
+                                onClick={() => {
+                                    setHasAnswered(false)
+                                    setSelectedOptionsIds(new Set())
+                                }}
+                            >
+                                Seuraava kysymys
+                            </Button>
+                        )}
+                        {hasAnswered && isLastQuestion ? (
+                            <Button
+                                variant="contained"
+                                color="primary"
+                                onClick={handleAnswer}
                             >
                                 Lopeta kysely
                             </Button>
@@ -111,15 +151,6 @@ export const FactQuizQuestionPage = () => {
                                 {questionId}/{totalQuestions}
                             </Typography>
                         )}
-                        <IconButton
-                            aria-label="next question"
-                            href={`/tietovisa/${questionId + 1}`}
-                            disabled={
-                                !totalQuestions || questionId >= totalQuestions
-                            }
-                        >
-                            <ArrowCircleRightIcon fontSize="large" />
-                        </IconButton>
                     </Stack>
                 </>
             )}


### PR DESCRIPTION
- Answer selections are reset when moving to next question
- `Vastaa` button is disabled, if no answers are selected
- After pressing `Vastaa` button, `Seuraava kysymys` button is displayed and user can move to next question
- After pressing `Vastaa` button on the last question, `Lopeta kysely` button is displayed instead of `Seuraava kysymys` button

This pull request has functionality that interacts with the backend but we have not built the backend side yet.

Please note that `quiz_repository.py` involves comment about need to create response id on quiz start, we can not do it on every questions like the current code does it.

Contributes to #239 