### PR TITLE
Summarypage: group statistics: -hidden if < 5 responses & -auto refresh

### DIFF
--- a/backend/src/api.py
+++ b/backend/src/api.py
@@ -98,9 +98,9 @@ def get_group(group_token):
 @api.route('/group/<string:group_token>/score', methods=['GET'])
 def get_group_score(group_token):
     try:
-        score = default_group_service.fetch_scores_by_group(
+        score, response_amount = default_group_service.fetch_scores_by_group(
             group_token)
-        return jsonify(score=score)
+        return jsonify(score=score, response_amount=response_amount)
     except Exception as error:  # pylint: disable=broad-except
         print(error)
         return jsonify(error="Something went wrong!"), 500

--- a/backend/src/repositories/group_repository.py
+++ b/backend/src/repositories/group_repository.py
@@ -40,7 +40,7 @@ class GroupRepository:
         try:
             sql = text(
                 """SELECT
-                        score, profile_id 
+                        score, profile_id, responses.id 
                     FROM 
                         responses, profile_answers, profile_questions 
                     WHERE 

--- a/backend/src/services/group_service.py
+++ b/backend/src/services/group_service.py
@@ -45,14 +45,22 @@ class GroupService:
             # Turn score from list of tuples into dict
             # e.g. [(50, 1), (75, 2), ..] =>
             # {1: 50, 2: 75, .. }
+            # And get amount of how many responses per id there is
             final_score = {}
-            for score, profile_id in scores:
+            response_ids = []
+            for score, profile_id, response_id in scores:
                 if profile_id not in final_score:
                     final_score[profile_id] = score
+                    if response_id not in response_ids:
+                        response_ids.append(response_id)
                 else:
                     final_score[profile_id] += score
+                    if response_id not in response_ids:
+                        response_ids.append(response_id)
+            response_amount = len(response_ids)
 
-            return final_score
+            return final_score, response_amount
+
         except Exception as error:
             raise error
 

--- a/backend/src/services/group_service.py
+++ b/backend/src/services/group_service.py
@@ -47,16 +47,15 @@ class GroupService:
             # {1: 50, 2: 75, .. }
             # And get amount of how many responses per id there is
             final_score = {}
-            response_ids = []
+            # Use set to count unique response_ids
+            response_ids = set()
             for score, profile_id, response_id in scores:
+                response_ids.add(response_id)
+                
                 if profile_id not in final_score:
                     final_score[profile_id] = score
-                    if response_id not in response_ids:
-                        response_ids.append(response_id)
                 else:
                     final_score[profile_id] += score
-                    if response_id not in response_ids:
-                        response_ids.append(response_id)
             response_amount = len(response_ids)
 
             return final_score, response_amount

--- a/backend/src/services/group_service.py
+++ b/backend/src/services/group_service.py
@@ -51,7 +51,6 @@ class GroupService:
             response_ids = set()
             for score, profile_id, response_id in scores:
                 response_ids.add(response_id)
-                
                 if profile_id not in final_score:
                     final_score[profile_id] = score
                 else:

--- a/frontend/src/pages/SummaryPage.jsx
+++ b/frontend/src/pages/SummaryPage.jsx
@@ -13,13 +13,12 @@ export const SummaryPage = () => {
     // Fetch all profiles from api
     const { data: profileData, isLoading: isLoadingProfiles } =
         useSWR('/api/profiles')
-
-    // Fetch result summary from api
+    // Fetch result summary from api. Refreshes group stats every 15 seconds
     const { data: summaryData, isLoading: isLoadingSummary } = useSWR(
         `/api/summary/${userId}`
     )
-    const { data: allProfileScores, isLoading: isLoadingAllProfileScores } =
-        useSWR(`/api/group/${groupToken}/score`)
+    const { data: allProfilesData, isLoading: isLoadingAllProfilesData } =
+        useSWR(`/api/group/${groupToken}/score`, { refreshInterval: 15000 })
 
     /* Turn the result key-value pairs into an array of objects with respective profile details
        e.g. { "1": 50, "2": 50, ..} => 
@@ -58,7 +57,7 @@ export const SummaryPage = () => {
         (result) => result.score === maxScore
     )
 
-    const groupSummaryScores = Object.entries(allProfileScores?.score || {})
+    const groupSummaryScores = Object.entries(allProfilesData?.score || {})
 
     const groupProfileResults = createProfileResultsFromScores(
         groupSummaryScores,
@@ -108,7 +107,7 @@ export const SummaryPage = () => {
                         </Typography>
                         {isLoadingProfiles ||
                         isLoadingSummary ||
-                        isLoadingAllProfileScores ? (
+                        isLoadingAllProfilesData ? (
                             <p>Loading...</p>
                         ) : answerCount > 0 ? (
                             <>
@@ -185,19 +184,30 @@ export const SummaryPage = () => {
                                                 },
                                             }}
                                         >
-                                            Ryhmäsi jakauma
+                                            Ryhmäsi {groupToken} jakauma
                                         </Typography>
-                                        <Box
-                                            width={{
-                                                xs: '60vw',
-                                                sm: '50vw',
-                                                md: '40vw',
-                                            }}
-                                        >
-                                            <SummaryDoughnut
-                                                data={groupProfileData}
-                                            />
-                                        </Box>
+
+                                        {allProfilesData.response_amount < 5 ? (
+                                            <Typography variant="body1">
+                                                Näet tässä ryhmäsi tulokset, kun
+                                                vähintään viisi henkilöä ovat
+                                                vastanneet kyselyyn.
+                                            </Typography>
+                                        ) : (
+                                            <>
+                                                <Box
+                                                    width={{
+                                                        xs: '60vw',
+                                                        sm: '50vw',
+                                                        md: '40vw',
+                                                    }}
+                                                >
+                                                    <SummaryDoughnut
+                                                        data={groupProfileData}
+                                                    />
+                                                </Box>
+                                            </>
+                                        )}
                                     </>
                                 )}
                             </>


### PR DESCRIPTION
Auto refresh:
- Summary page updates every 15 seconds with SWR, if there is a groupToken to show the up to date group results.

Hidden responses:
- Changed SQL command to contain response_id as well.  Group service counts the different response_ids and returns the length, aka the amount of different people who have answered.
- The response amount is used in Summary page, where it works as a condition to not show the group statistic block if there is less than 5 answers.