### PR TITLE
Group link to group summary page

### DIFF
--- a/backend/src/api.py
+++ b/backend/src/api.py
@@ -85,6 +85,19 @@ def new_group():
         return jsonify(error="Something went wrong!"), 500
 
 
+@api.route('/group/<string:group_token>/summary', methods=['GET'])
+def group_summary(group_token):
+    try:
+        if not default_group_service.check_if_group_exists(group_token):
+            return jsonify({"status": "fail",
+                            "message": "Group does not exist"}), 400
+        return jsonify({"status": "success",
+                        "message": "Group exists"}), 200
+    except Exception as error:  # pylint: disable=broad-except
+        print(error)
+        return jsonify(error="Something went wrong!"), 500
+
+
 @api.route('/group/<string:group_token>', methods=['GET'])
 def get_group(group_token):
     try:

--- a/frontend/src/components/GroupSummaryDialog.jsx
+++ b/frontend/src/components/GroupSummaryDialog.jsx
@@ -1,0 +1,97 @@
+import * as React from 'react'
+import { useNavigate } from 'react-router-dom'
+import {
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    DialogContentText,
+    DialogActions,
+    TextField,
+    Button,
+} from '@mui/material'
+
+export default function GroupSummaryDialog() {
+    const [groupName, setGroupName] = React.useState('')
+    const [open, setOpen] = React.useState(false)
+    const navigate = useNavigate()
+
+    const handleGroupNameChange = (event) => {
+        setGroupName(event.target.value.toUpperCase())
+    }
+
+    const handleSubmit = () => {
+        if (groupName === '') {
+            window.alert('Ryhmätunnus ei voi olla tyhjä merkkijono.')
+            return
+        } else if (groupName.length > 10) {
+            window.alert('Ryhmätunnus ei voi olla yli 10 merkkiä pitkä.')
+            return
+        } else if (!/^[A-Z0-9]+$/.test(groupName)) {
+            window.alert(
+                'Ryhmätunnus voi sisältää vain isoja kirjaimia ja numeroita.'
+            )
+            return
+        }
+        fetch(`/api/group/${groupName}/summary`, {
+            method: 'GET',
+        })
+            .then((response) => response.json())
+            .then(() => {
+                navigate(`/group/${groupName}/summary`)
+                setOpen(false)
+            })
+            .catch((error) => console.error(error))
+    }
+
+    return (
+        <div>
+            <Button
+                id="btn-group-summary-dialog"
+                variant="outlined"
+                color="secondary"
+                onClick={() => setOpen(true)}
+            >
+                Ryhmän jakauma
+            </Button>
+            <Dialog
+                id="group-summary-dialog"
+                open={open}
+                onClose={() => setOpen(false)}
+            >
+                <DialogTitle>Siirry katsomaan ryhmän jakaumaa</DialogTitle>
+                <DialogContent>
+                    <DialogContentText>
+                        Jos haluat siirtyä katsomaan ryhmäsi jakumaa, kirjoita
+                        ryhmätunnus:
+                    </DialogContentText>
+                    <TextField
+                        autoFocus
+                        margin="dense"
+                        label="Ryhmäntunnus"
+                        type="text"
+                        fullWidth
+                        variant="standard"
+                        value={groupName}
+                        onChange={handleGroupNameChange}
+                        id="input-group-token"
+                    />
+                </DialogContent>
+                <DialogActions>
+                    <Button
+                        id="btn-cancel-group-summary"
+                        onClick={() => setOpen(false)}
+                    >
+                        EIKU
+                    </Button>
+                    <Button
+                        id="btn-move-to-group-summary"
+                        onClick={handleSubmit}
+                        color="primary"
+                    >
+                        Siirry
+                    </Button>
+                </DialogActions>
+            </Dialog>
+        </div>
+    )
+}

--- a/frontend/src/components/GroupSummaryDialog.jsx
+++ b/frontend/src/components/GroupSummaryDialog.jsx
@@ -11,7 +11,7 @@ import {
 } from '@mui/material'
 
 export default function GroupSummaryDialog() {
-    const [groupName, setGroupName] = React.useState('')
+    const [groupToken, setGroupName] = React.useState('')
     const [open, setOpen] = React.useState(false)
     const navigate = useNavigate()
 
@@ -20,27 +20,26 @@ export default function GroupSummaryDialog() {
     }
 
     const handleSubmit = () => {
-        if (groupName === '') {
-            window.alert('Ryhmätunnus ei voi olla tyhjä merkkijono.')
-            return
-        } else if (groupName.length > 10) {
-            window.alert('Ryhmätunnus ei voi olla yli 10 merkkiä pitkä.')
-            return
-        } else if (!/^[A-Z0-9]+$/.test(groupName)) {
-            window.alert(
-                'Ryhmätunnus voi sisältää vain isoja kirjaimia ja numeroita.'
-            )
-            return
-        }
-        fetch(`/api/group/${groupName}/summary`, {
+        fetch(`/api/group/${groupToken}`, {
             method: 'GET',
+            headers: { 'Content-Type': 'application/json' },
         })
-            .then((response) => response.json())
-            .then(() => {
-                navigate(`/group/${groupName}/summary`)
-                setOpen(false)
+            .then((response) => {
+                if (!response.ok) {
+                    throw new Error('Verkkoyhteysvirhe')
+                }
+                return response.json()
             })
-            .catch((error) => console.error(error))
+            .then((data) => {
+                if (data.group_token) {
+                    localStorage.setItem('groupToken', groupToken)
+                    window.dispatchEvent(new Event('setGroupToken'))
+                    navigate(`/yhteenveto/ryhma/${groupToken}`)
+                    setOpen(false)
+                } else {
+                    alert('Ryhmätunnusta ei löytynyt.')
+                }
+            })
     }
 
     return (
@@ -71,7 +70,7 @@ export default function GroupSummaryDialog() {
                         type="text"
                         fullWidth
                         variant="standard"
-                        value={groupName}
+                        value={groupToken}
                         onChange={handleGroupNameChange}
                         id="input-group-token"
                     />

--- a/frontend/src/components/GroupSummaryDialog.jsx
+++ b/frontend/src/components/GroupSummaryDialog.jsx
@@ -60,7 +60,7 @@ export default function GroupSummaryDialog() {
                 <DialogTitle>Siirry katsomaan ryhmän jakaumaa</DialogTitle>
                 <DialogContent>
                     <DialogContentText>
-                        Jos haluat siirtyä katsomaan ryhmäsi jakumaa, kirjoita
+                        Jos haluat siirtyä katsomaan ryhmäsi jakaumaa, kirjoita
                         ryhmätunnus:
                     </DialogContentText>
                     <TextField

--- a/frontend/src/pages/GroupSummaryPage.jsx
+++ b/frontend/src/pages/GroupSummaryPage.jsx
@@ -88,7 +88,7 @@ export const GroupSummaryPage = () => {
                                     <Typography variant="body1">
                                         Näet tässä ryhmäsi tulokset, kun
                                         vähintään viisi henkilöä ovat vastanneet
-                                        kyselyyn. Nyt on vastannut{' '}
+                                        kyselyyn. Nyt kyselyyn on vastannut{' '}
                                         {allProfilesData.response_amount}{' '}
                                         henkilöä.
                                     </Typography>

--- a/frontend/src/pages/GroupSummaryPage.jsx
+++ b/frontend/src/pages/GroupSummaryPage.jsx
@@ -133,7 +133,7 @@ export const GroupSummaryPage = () => {
                                             }}
                                         >
                                             Ryhmän {groupToken} jakauma.
-                                            Ryhmässä on vastannut{' '}
+                                            Ryhmässä kyselyyn on vastannut{' '}
                                             {allProfilesData.response_amount}{' '}
                                             henkilöä.
                                         </Typography>

--- a/frontend/src/pages/GroupSummaryPage.jsx
+++ b/frontend/src/pages/GroupSummaryPage.jsx
@@ -87,7 +87,7 @@ export const GroupSummaryPage = () => {
                                 {allProfilesData.response_amount < 5 ? (
                                     <Typography variant="body1">
                                         Näet tässä ryhmäsi tulokset, kun
-                                        vähintään viisi henkilöä ovat vastanneet
+                                        vähintään viisi henkilöä on vastannut
                                         kyselyyn. Nyt kyselyyn on vastannut{' '}
                                         {allProfilesData.response_amount}{' '}
                                         henkilöä.

--- a/frontend/src/pages/GroupSummaryPage.jsx
+++ b/frontend/src/pages/GroupSummaryPage.jsx
@@ -1,0 +1,9 @@
+import { Typography } from '@mui/material'
+
+export const GroupSummaryPage = () => {
+    return (
+        <Typography variant="h1" align="center">
+            Hello world
+        </Typography>
+    )
+}

--- a/frontend/src/pages/GroupSummaryPage.jsx
+++ b/frontend/src/pages/GroupSummaryPage.jsx
@@ -1,9 +1,160 @@
-import { Typography } from '@mui/material'
+import useSWR from 'swr'
+import { Typography, Container, Stack, Box, Card } from '@mui/material'
+import { useTitle } from '../hooks/useTitle'
+import { SummaryProfile } from '../components/SummaryProfile'
+import SummaryDoughnut from '../components/SummaryDoughnut'
 
 export const GroupSummaryPage = () => {
+    const groupToken = localStorage.getItem('groupToken')
+
+    // Fetch all profiles from api
+    const { data: profileData, isLoading: isLoadingProfiles } =
+        useSWR('/api/profiles')
+
+    const { data: allProfilesData, isLoading: isLoadingAllProfilesData } =
+        useSWR(`/api/group/${groupToken}/score`, { refreshInterval: 15000 })
+
+    /* Turn the result key-value pairs into an array of objects with respective profile details
+       e.g. { "1": 50, "2": 50, ..} => 
+        [
+            { id: 1, score: 25%, name: .., description: ..}, 
+            { id: 2, score: 25%, name: .., description: ..}, 
+            ..
+        ]
+    */
+
+    const createProfileResultsFromScores = (scores, profiles) => {
+        const totalScore = scores.reduce((acc, score) => acc + score[1], 0)
+
+        return scores.map((score) => ({
+            score: (score[1] / totalScore) * 100,
+            // Include matching climate profile id, name and desc
+            ...profiles?.find((profile) => profile.id == parseInt(score[0])),
+        }))
+    }
+
+    const groupSummaryScores = Object.entries(allProfilesData?.score || {})
+
+    const groupProfileResults = createProfileResultsFromScores(
+        groupSummaryScores,
+        profileData
+    )
+
+    const groupProfileData = groupProfileResults?.map((result) => ({
+        id: result.id,
+        value: result.score,
+        label: result.name,
+    }))
+
+    const maxScore = groupProfileResults.reduce(
+        (max, result) => (max.score > result.score ? max : result),
+        {}
+    ).score
+
+    const highestScoreProfiles = groupProfileResults.filter(
+        (result) => result.score === maxScore
+    )
+
+    useTitle('Ilmastoprofiili - Tulokset')
     return (
-        <Typography variant="h1" align="center">
-            Hello world
-        </Typography>
+        <Container>
+            <Box paddingY={5}>
+                <Card>
+                    <Stack
+                        spacing={4}
+                        paddingTop={'30px'}
+                        paddingBottom={'50px'}
+                        alignItems={'center'}
+                    >
+                        <Typography
+                            variant="h1"
+                            sx={{
+                                fontSize: {
+                                    xs: '2em', // Smaller font size for extra small screens
+                                    sm: '3em', // Slightly bigger for small screens
+                                    md: '4em', // Original size for medium screens and up
+                                },
+                                textAlign: 'center',
+                                p: '20px',
+                            }}
+                        >
+                            Ryhmän ilmastoprofiili
+                        </Typography>
+                        {isLoadingProfiles || isLoadingAllProfilesData ? (
+                            <p>Loading...</p>
+                        ) : (
+                            <>
+                                {allProfilesData.response_amount < 5 ? (
+                                    <Typography variant="body1">
+                                        Näet tässä ryhmäsi tulokset, kun
+                                        vähintään viisi henkilöä ovat vastanneet
+                                        kyselyyn. Nyt on vastannut{' '}
+                                        {allProfilesData.response_amount}{' '}
+                                        henkilöä.
+                                    </Typography>
+                                ) : (
+                                    <>
+                                        {highestScoreProfiles.length > 1 && (
+                                            <Typography
+                                                variant="h2"
+                                                sx={{
+                                                    fontSize: {
+                                                        xs: '1em',
+                                                        sm: '1.25em',
+                                                        md: '1.5em',
+                                                    },
+                                                }}
+                                            >
+                                                Teillä on useita profiileja,
+                                                jotka kuvastavat ryhmäänne!
+                                            </Typography>
+                                        )}
+                                        {highestScoreProfiles.map(
+                                            (profile, index) => (
+                                                <SummaryProfile
+                                                    key={profile.id}
+                                                    index={index}
+                                                    title={profile.name}
+                                                    description={
+                                                        profile.description
+                                                    }
+                                                />
+                                            )
+                                        )}
+
+                                        <Typography
+                                            variant="h2"
+                                            sx={{
+                                                fontSize: {
+                                                    xs: '1em',
+                                                    sm: '1.25em',
+                                                    md: '1.5em',
+                                                },
+                                            }}
+                                        >
+                                            Ryhmän {groupToken} jakauma.
+                                            Ryhmässä on vastannut{' '}
+                                            {allProfilesData.response_amount}{' '}
+                                            henkilöä.
+                                        </Typography>
+                                        <Box
+                                            width={{
+                                                xs: '60vw',
+                                                sm: '50vw',
+                                                md: '40vw',
+                                            }}
+                                        >
+                                            <SummaryDoughnut
+                                                data={groupProfileData}
+                                            />
+                                        </Box>
+                                    </>
+                                )}
+                            </>
+                        )}
+                    </Stack>
+                </Card>
+            </Box>
+        </Container>
     )
 }

--- a/frontend/src/pages/SurveyPage.jsx
+++ b/frontend/src/pages/SurveyPage.jsx
@@ -10,6 +10,7 @@ import { NavLink } from 'react-router-dom'
 import styled from '@emotion/styled'
 import FormDialog from '../components/FormDialog'
 import GroupDialog from '../components/GroupDialog'
+import GroupSummaryDialog from '../components/GroupSummaryDialog'
 import { useTitle } from '../hooks/useTitle'
 
 const SurveyOptionButton = styled(Button)`
@@ -69,8 +70,11 @@ export function SurveyPage() {
                                     Teen kyselyn yksin
                                 </Typography>
                             </SurveyOptionButton>
-                            <Box alignSelf="center">
+                            <Box alignSelf="center" paddingTop={2}>
                                 <GroupDialog />
+                            </Box>
+                            <Box alignSelf="center">
+                                <GroupSummaryDialog />
                             </Box>
                         </Stack>
                     </Box>

--- a/frontend/src/router.jsx
+++ b/frontend/src/router.jsx
@@ -6,7 +6,7 @@ import { QuestionPage } from './pages/QuestionPage'
 import { ClimateProfilePage } from './pages/ClimateProfilePage'
 import { SummaryPage } from './pages/SummaryPage'
 import { FactQuizQuestionPage } from './pages/FactQuizQuestionPage'
-
+import { GroupSummaryPage } from './pages/GroupSummaryPage'
 // Defines the routes of the application
 export const routes = [
     {
@@ -35,6 +35,10 @@ export const routes = [
             {
                 path: '/yhteenveto/:userId',
                 element: <SummaryPage />,
+            },
+            {
+                path: '/yhteenveto/ryhma/:groupToken',
+                element: <GroupSummaryPage />,
             },
         ],
     },

--- a/frontend/src/tests/surveyPage.test.js
+++ b/frontend/src/tests/surveyPage.test.js
@@ -21,7 +21,7 @@ describe('Survey page', () => {
         expect(links.length).toBe(1)
 
         const buttons = screen.getAllByRole('button')
-        expect(buttons.length).toBe(2)
+        expect(buttons.length).toBe(3)
     })
 
     test('Survey start link', () => {


### PR DESCRIPTION
Created separate page to view group summary statistics. Added button in "kysely"-page, to access the group statistic page without doing a survey.