### PR TITLE
Set max width to progress bar

### DIFF
--- a/frontend/src/pages/QuestionPage.jsx
+++ b/frontend/src/pages/QuestionPage.jsx
@@ -137,7 +137,7 @@ export function QuestionPage() {
                         <LinearProgress
                             variant="determinate"
                             value={(questionId * 100) / totalQuestions}
-                            style={{ width: '70%' }}
+                            style={{ width: '70%', maxWidth: '780px' }}
                         />
                         <Stack
                             direction="row"


### PR DESCRIPTION
Set max width to progress bar, so it doesn't get too wide on a large resolution.