### PR TITLE
Force a docker compose build before watching for changes

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -7,4 +7,5 @@ ensure_supported_docker_compose_version
 
 trap 'run_command docker compose down' EXIT
 
+run_command docker compose build
 run_command docker compose watch "$@"

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,10 +1,18 @@
-FROM node:18-alpine as build
+FROM node:18-alpine as deps
 
 WORKDIR /app
 
-COPY . .
+COPY package.json package-lock.json .
 
 RUN npm ci
+
+FROM deps as runtime
+
+WORKDIR /app
+
+COPY --from=deps /app .
+
+COPY . .
 
 EXPOSE 5173
 


### PR DESCRIPTION
We should now handle the common case where changes were made after first run of ``docker compose watch``.