### PR TITLE
fix fragment error on menu and padding on groupsummary

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -248,7 +248,7 @@ function ResponsiveAppBar() {
                                 </Typography>
                             </MenuItem>
                             {groupToken ? (
-                                <>
+                                <Box>
                                     <MenuItem
                                         key="GroupSummary"
                                         id="btn-group-summary"
@@ -280,7 +280,7 @@ function ResponsiveAppBar() {
                                     >
                                         <Typography>Poistu ryhmästä</Typography>
                                     </MenuItem>
-                                </>
+                                </Box>
                             ) : null}
                         </Menu>
                     </Box>

--- a/frontend/src/pages/GroupSummaryPage.jsx
+++ b/frontend/src/pages/GroupSummaryPage.jsx
@@ -65,6 +65,7 @@ export const GroupSummaryPage = () => {
                         spacing={4}
                         paddingTop={'30px'}
                         paddingBottom={'50px'}
+                        padding={'20px'}
                         alignItems={'center'}
                     >
                         <Typography


### PR DESCRIPTION
Fragment error fixed in navbar Menu, and padding added to groupsummary to make it look nicer.

Closes #354 & #355 