### PR TITLE
ui changes to make group joining a better user experience

### DIFF
--- a/frontend/cypress/e2e/groupJoining.cy.js
+++ b/frontend/cypress/e2e/groupJoining.cy.js
@@ -9,22 +9,22 @@ Cypress.env('screen_sizes').forEach((size) => {
         })
 
         it('Open join-group dialog and joining with nonexistent group token fails', function () {
-            cy.joinGroupWithToken('TOKENI', 'Ryhmään liittyminen epäonnistui!')
+            cy.joinGroupWithToken('TOKENI', 'Ryhmään liittyminen epäonnistui.')
         })
 
         it('Open join-group dialog and joining with empty inputfield fails', function () {
-            cy.joinGroupWithToken('', 'Ryhmään liittyminen epäonnistui!')
+            cy.joinGroupWithToken('', 'Ryhmään liittyminen epäonnistui.')
         })
 
         it('Open join-group dialog and joining with too long token fails', function () {
             cy.joinGroupWithToken(
                 'LIIANPITKATUNNUS',
-                'Ryhmään liittyminen epäonnistui!'
+                'Ryhmään liittyminen epäonnistui.'
             )
         })
 
         it('Open join-group dialog and joining with special character fails', function () {
-            cy.joinGroupWithToken('MOI!!!', 'Ryhmään liittyminen epäonnistui!')
+            cy.joinGroupWithToken('MOI!!!', 'Ryhmään liittyminen epäonnistui.')
         })
         // Remember to reste database before running this test
 

--- a/frontend/src/components/GroupDialog.jsx
+++ b/frontend/src/components/GroupDialog.jsx
@@ -8,6 +8,7 @@ import {
     DialogActions,
     TextField,
     Button,
+    Typography,
 } from '@mui/material'
 
 export default function GroupDialog() {
@@ -83,7 +84,7 @@ export default function GroupDialog() {
                 color="secondary"
                 onClick={() => setOpen(true)}
             >
-                Luo ryhmä
+                <Typography>Luo ryhmä</Typography>
             </Button>
             {!groupIsMade ? (
                 <Dialog
@@ -142,10 +143,16 @@ export default function GroupDialog() {
                     </DialogTitle>
                     <DialogContent>
                         <DialogContentText>
-                            Muistathan kertoa ryhmään osallistuville
-                            ryhmätunnuksen liittymistä varten. Ryhmään liittyviä
-                            toiminnallisuuksia pääset tarkastelemaan oikean
-                            yläkulman painikkeesta.
+                            - Kerro ryhmään osallistuville ryhmätunnuksen
+                            liittymistä varten.
+                        </DialogContentText>
+                        <DialogContentText>
+                            - Ryhmän luojana et ole vielä osana ryhmää. Jos
+                            haluat tehdä kyselyjä ryhmässä, muistathan liittyä.
+                        </DialogContentText>
+                        <DialogContentText>
+                            - Ryhmään liittyviä toiminnallisuuksia pääset
+                            tarkastelemaan oikean yläkulman painikkeesta.
                         </DialogContentText>
                     </DialogContent>
                     <DialogActions>

--- a/frontend/src/components/JoinGroup.jsx
+++ b/frontend/src/components/JoinGroup.jsx
@@ -2,7 +2,7 @@ import {
     Box,
     FormControl,
     FormHelperText,
-    IconButton,
+    Button,
     InputBase,
     Paper,
     Stack,
@@ -53,11 +53,9 @@ const JoinGroup = () => {
         <Box paddingTop={2}>
             <Stack>
                 <Stack
-                    sx={{
-                        display: 'flex',
-                        flexDirection: 'row',
-                    }}
-                    direction={'row'}
+                    direction={{ xs: 'column', sm: 'row' }}
+                    justifyContent={'space-evenly'}
+                    alignItems={{xs: 'center', sm: 'flex-start'}}
                     spacing={4}
                 >
                     <FormControl error={!isValid} variant="outlined">
@@ -76,17 +74,19 @@ const JoinGroup = () => {
                                 value={groupToken}
                                 onChange={handleTextFieldChange}
                             />
-                            <IconButton
+                            <Button
                                 id="btn-join-group"
                                 type="button"
                                 onClick={handleSubmit}
+                                color="secondary"
+                                variant="contained"
                             >
                                 <Typography>Liity</Typography>
-                            </IconButton>
+                            </Button>
                         </Paper>
                         {!isValid && (
                             <FormHelperText>
-                                Ryhmään liittyminen epäonnistui!
+                                Ryhmään liittyminen epäonnistui.
                             </FormHelperText>
                         )}
                         {joinedToGroup && (
@@ -100,6 +100,7 @@ const JoinGroup = () => {
                             </FormHelperText>
                         )}
                     </FormControl>
+
                     <GroupDialog />
                 </Stack>
             </Stack>

--- a/frontend/src/pages/SurveyPage.jsx
+++ b/frontend/src/pages/SurveyPage.jsx
@@ -6,6 +6,7 @@ import {
     Card,
     Container,
     CardContent,
+    Link,
 } from '@mui/material'
 
 import { useTitle } from '../hooks/useTitle'
@@ -59,7 +60,9 @@ export function SurveyPage() {
                                 liittyviin asenteisiisi. Voit vastata kyselyyn
                                 painamalla &quot;Aloita&quot; painiketta. Kun
                                 olet vastannut kyselyyn saat selville, mikä
-                                neljästä ilmastoroolista kuvastaa sinua.
+                                neljästä ilmastoroolista kuvastaa sinua. Voit
+                                tutustua ilmastorooleihin{" "}
+                                <Link href={`/ilmastoroolit`}>täältä!</Link>
                             </Typography>
                             <Typography marginBottom={2} variant="h6">
                                 Vastaaminen ryhmässä
@@ -83,26 +86,21 @@ export function SurveyPage() {
                                     style={{
                                         width: 200,
                                         height: 100,
-                                        fontSize: '20px',
                                     }}
                                     id="btn-survey-alone"
                                     data-testid="btn-start-survey"
                                     variant="contained"
                                     href="/kysymys/1"
-                                    color="secondary"
+                                    color="primary"
                                 >
-                                    Aloita
+                                    <Typography
+                                        fontWeight={'medium'}
+                                        letterSpacing={2}
+                                    >
+                                        Aloita !
+                                    </Typography>
                                 </Button>
                             </Stack>
-                        </CardContent>
-                    </Card>
-
-                    <Card>
-                        <CardContent>
-                            <Typography>
-                                Tällä hetkellä pääset katsomaan ilmastorooleja
-                                yläpalkista. Jatkossa ne löytyvät täältä.
-                            </Typography>
                         </CardContent>
                     </Card>
                 </Stack>

--- a/frontend/src/tests/surveyPage.test.js
+++ b/frontend/src/tests/surveyPage.test.js
@@ -16,9 +16,9 @@ describe('Survey page', () => {
         screen.getByText('Ilmastoroolikysely')
     })
 
-    test('renders buttons', () => {
+    test('renders button and link', () => {
         const links = screen.getAllByRole('link')
-        expect(links.length).toBe(1)
+        expect(links.length).toBe(2)
     })
 
     test('Survey start link', () => {


### PR DESCRIPTION
- Made "liity" into a clear button to avoid confusion in joining group.
- Joining group , and creating group components are in a row, but switch to a column on xs screen
- Some wording changes in texts
- added link to ilmastoroolit page from ilmastoroolikysely instead of the placeholder card below the actual content. 
