### PR TITLE
Add Group summary Cypress tests

### DIFF
--- a/frontend/cypress/e2e/groupSummary.cy.js
+++ b/frontend/cypress/e2e/groupSummary.cy.js
@@ -49,6 +49,26 @@ describe('Group summary page', function () {
                         'Näet tässä ryhmän FOOBAR tulokset, kun vähintään viisi henkilöä on vastannut kyselyyn. Nyt kyselyyn on vastannut 0 henkilöä.'
                     )
                 })
+
+                it('Show summary for group with 5 answers', function () {
+                    cy.createGroupWithApi(groupToken)
+                    cy.joinGroup(groupToken)
+
+                    for (var i = 0; i < 5; i++) {
+                        cy.answerRoleSurveyWithApi(groupToken, {
+                            1: 1,
+                            2: 1,
+                            3: 1,
+                            4: 1,
+                            5: 1,
+                        })
+                    }
+                    cy.visit('/yhteenveto/ryhma/' + groupToken)
+                    cy.contains('Ryhmän FOOBAR ilmastorooli')
+                    cy.contains(
+                        'Ryhmän FOOBAR jakauma. Kyselyyn on vastannut 5 henkilöä.'
+                    )
+                })
             }
         )
     })

--- a/frontend/cypress/e2e/groupSummary.cy.js
+++ b/frontend/cypress/e2e/groupSummary.cy.js
@@ -1,0 +1,55 @@
+describe('Group summary page', function () {
+    const groupToken = 'FOOBAR'
+
+    beforeEach(() => cy.visit('/'))
+
+    Cypress.env('viewports').forEach((viewport) => {
+        describe(
+            `on ${viewport[0]}x${viewport[1]} viewport`,
+            {
+                viewportWidth: viewport[0],
+                viewportHeight: viewport[1],
+            },
+            () => {
+                beforeEach(() => {
+                    cy.findByTestId('group-token-input').as('groupTokenInput')
+                    cy.findByTestId('join-group').as('joinGroup')
+
+                    cy.exec('../bin/db-reset')
+                })
+
+                it('Create and join group, visit group summary through URL, 0 answers', function () {
+                    cy.createGroupWithApi(groupToken)
+                    cy.get('@groupTokenInput').get('input').type(groupToken)
+                    cy.get('@joinGroup').click()
+
+                    cy.visit('/yhteenveto/ryhma/' + groupToken)
+                    cy.contains('Ryhmän FOOBAR ilmastorooli')
+                    cy.contains(
+                        'Näet tässä ryhmän FOOBAR tulokset, kun vähintään viisi henkilöä on vastannut kyselyyn. Nyt kyselyyn on vastannut 0 henkilöä.'
+                    )
+                })
+
+                it('Create and join group, visit group summary through hamburger menu, 0 answer', function () {
+                    cy.createGroupWithApi(groupToken)
+                    cy.get('@groupTokenInput').get('input').type(groupToken)
+                    cy.get('@joinGroup').click()
+
+                    cy.findByTestId('show-group-menu').click()
+                    cy.findByTestId('group-menu')
+                        .should('be.visible')
+                        .within(() => {
+                            cy.findByTestId('current-group-token').contains(
+                                groupToken
+                            )
+                            cy.findByTestId('open-group-summary').click()
+                        })
+                    cy.contains('Ryhmän FOOBAR ilmastorooli')
+                    cy.contains(
+                        'Näet tässä ryhmän FOOBAR tulokset, kun vähintään viisi henkilöä on vastannut kyselyyn. Nyt kyselyyn on vastannut 0 henkilöä.'
+                    )
+                })
+            }
+        )
+    })
+})

--- a/frontend/cypress/index.d.ts
+++ b/frontend/cypress/index.d.ts
@@ -1,28 +1,37 @@
 declare namespace Cypress {
     interface Chainable<Subject> {
-      /**
-       * Type into DOM element if the input is not empty
-       * @example
-       * cy.getByTestId('group-token').typeIfNotEmpty(tokenValue)
-       */
-      typeIfNotEmpty(textToType: string): Chainable<any>
-      /**
-       * Creates one group using the API
-       * @example
-       * cy.createGroupWithApi('HELLU2')
-       */
-      createGroupWithApi(groupToken: string): Chainable<any>
-      /**
-       * Checks whether the group exists before setting the group token in the local storage
-       * @example
-       * cy.joinGroup('HELLU2')
-       */
-      joinGroup(groupToken: string): Chainable<any>
-      /**
-       * Navigates to a page using the navigation bar
-       * @example
-       * cy.navigateToPageWithNavBar('survey')
-       */
-      navigateToPageWithNavBar(pageId: string): Chainable<any>
+        /**
+         * Type into DOM element if the input is not empty
+         * @example
+         * cy.getByTestId('group-token').typeIfNotEmpty(tokenValue)
+         */
+        typeIfNotEmpty(textToType: string): Chainable<any>
+        /**
+         * Creates one group using the API
+         * @example
+         * cy.createGroupWithApi('HELLU2')
+         */
+        createGroupWithApi(groupToken: string): Chainable<any>
+        /**
+         * Creates one group using the API
+         * @example
+         * cy.createGroupWithApi('HELLU2', {"1": 3, "2": 2})
+         */
+        answerRoleSurveyWithApi(
+            groupToken: string,
+            answers: any
+        ): Chainable<any>
+        /**
+         * Checks whether the group exists before setting the group token in the local storage
+         * @example
+         * cy.joinGroup('HELLU2')
+         */
+        joinGroup(groupToken: string): Chainable<any>
+        /**
+         * Navigates to a page using the navigation bar
+         * @example
+         * cy.navigateToPageWithNavBar('survey')
+         */
+        navigateToPageWithNavBar(pageId: string): Chainable<any>
     }
-  }
+}

--- a/frontend/cypress/support/commands.js
+++ b/frontend/cypress/support/commands.js
@@ -22,6 +22,15 @@ Cypress.Commands.add('createGroupWithApi', (groupToken) => {
     )
 })
 
+Cypress.Commands.add('answerRoleSurveyWithApi', (groupToken, responses) => {
+    cy.request('POST', '/api/submit', {
+        groupToken: groupToken,
+        responses: responses,
+    }).then((response) => {
+        expect(response.body).to.have.property('status', 'success')
+    })
+})
+
 Cypress.Commands.add('joinGroup', (groupToken) => {
     cy.request('/api/group/' + groupToken).then((response) => {
         expect(response.body).to.have.property('group_token', true)


### PR DESCRIPTION
There is some weird Cypress magic happening currently and the group summary page doesn't render climate roles of group, which blocks generating further tests.

Contributes to #306