### PR TITLE
Use MUI provided responsive font size configuration

### DIFF
--- a/frontend/src/theme.jsx
+++ b/frontend/src/theme.jsx
@@ -1,28 +1,35 @@
-import { createTheme } from '@mui/material'
+import { createTheme, responsiveFontSizes } from '@mui/material'
 import { LinkBehavior } from './components/LinkBehavior'
 
-export const theme = createTheme({
-    typography: {
-        button: {
-            textTransform: 'none',
+export const theme = responsiveFontSizes(
+    createTheme({
+        typography: {
+            button: {
+                textTransform: 'none',
+            },
         },
-    },
-    palette: {
-        primary: {
-            main: '#27632a',
+        palette: {
+            primary: {
+                main: '#27632a',
+            },
+            secondary: {
+                main: '#3949ab',
+            },
+            contrastThreshold: 4.5,
         },
-        secondary: {
-            main: '#3949ab',
+        components: {
+            MuiLink: {
+                defaultProps: { component: LinkBehavior },
+            },
+            MuiButtonBase: {
+                defaultProps: { LinkComponent: LinkBehavior },
+            },
         },
         background: { paper: '#FAFAF8' },
         contrastThreshold: 4.5,
-    },
-    components: {
-        MuiLink: {
-            defaultProps: { component: LinkBehavior },
-        },
-        MuiButtonBase: {
-            defaultProps: { LinkComponent: LinkBehavior },
-        },
-    },
-})
+    }),
+    {
+        /* https://mui.com/material-ui/customization/theming/#responsivefontsizes-theme-options-theme */
+        factor: 2,
+    }
+)


### PR DESCRIPTION
Use [MUI's `responsiveFontSizes(theme, responsiveFontSizesOptions)`](https://mui.com/material-ui/customization/theming/#responsivefontsizes-theme-options-theme) to configure its default responsive typography properties at the theme level. 
The default configuraiton scales the typography to be smaller for smaller viewports by a given factor, as seen in the the chart below:

![image](https://github.com/Ilmastokompassi/Ilmastokompassi/assets/26825431/26e53ed4-5183-414b-95b6-e278da72d163)

This allows to use semantically correct typography variants which now scale accordingly for smaller viewports.

Contributes to #411 