### PR TITLE
Change heading font sizes to larger ones

### DIFF
--- a/frontend/src/components/NavigationBar.jsx
+++ b/frontend/src/components/NavigationBar.jsx
@@ -34,7 +34,7 @@ const Logo = () => (
     >
         <Stack direction="row" alignItems="center" spacing={0.5}>
             <img src={Compass} alt="logo" width={40} />
-            <Typography variant="h6" fontFamily="sans-serif" fontWeight="bold">
+            <Typography variant="h2" fontFamily="sans-serif" fontWeight="bold">
                 Ilmastokompassi
             </Typography>
         </Stack>
@@ -197,7 +197,9 @@ const NavigationBar = () => {
                                             variant="contained"
                                             disableElevation
                                         >
-                                            {page.name}
+                                            <Typography variant="h3">
+                                                {page.name}
+                                            </Typography>
                                         </Button>
                                     ))}
                                 </Box>

--- a/frontend/src/components/ToSurveyCard.jsx
+++ b/frontend/src/components/ToSurveyCard.jsx
@@ -47,10 +47,10 @@ export const ToSurveyCard = ({ name, description, to, icon }) => {
                             alignItems="center"
                         >
                             <Stack>
-                                <Typography variant="h2" paddingBottom={3}>
+                                <Typography variant="h1" paddingBottom={3}>
                                     {name}
                                 </Typography>
-                                <Typography variant="h5" component="div">
+                                <Typography variant="h3" component="div">
                                     {description}
                                 </Typography>
                             </Stack>

--- a/frontend/src/components/roleSurvey/SummaryRole.jsx
+++ b/frontend/src/components/roleSurvey/SummaryRole.jsx
@@ -17,8 +17,8 @@ export const SummaryRole = ({ role }) => {
         >
             <RoleImage role={role} />
             <Box>
-                <Typography variant="h5">{role.name}</Typography>
-                <Typography>{role.description}</Typography>
+                <Typography variant="h2">{role.name}</Typography>
+                <Typography variant="h3">{role.description}</Typography>
             </Box>
         </Stack>
     )

--- a/frontend/src/pages/FactQuizSummaryPage.jsx
+++ b/frontend/src/pages/FactQuizSummaryPage.jsx
@@ -34,7 +34,7 @@ export const FactQuizSummaryPage = () => {
                             padding={{ xs: 1, md: 4 }}
                         >
                             <Stack alignItems="center" spacing={3} paddingY={2}>
-                                <Typography variant="h4" textAlign={'center'}>
+                                <Typography variant="h3" textAlign={'center'}>
                                     Hyvää työtä !
                                 </Typography>
                                 <Box
@@ -51,9 +51,9 @@ export const FactQuizSummaryPage = () => {
                                     paddingBottom={2}
                                     textAlign={'center'}
                                 >
-                                    Olet seikkaillut oppimisvisan loppuun saakka.
-                                    Tästä voit vielä tarkastella, mitä kaikkea
-                                    sitä tulikaan käytyä läpi.
+                                    Olet seikkaillut oppimisvisan loppuun
+                                    saakka. Tästä voit vielä tarkastella, mitä
+                                    kaikkea sitä tulikaan käytyä läpi.
                                 </Typography>
                             </Stack>
                             {isLoadingAllSummaryInfo ? (

--- a/frontend/src/pages/FaqPage.jsx
+++ b/frontend/src/pages/FaqPage.jsx
@@ -9,14 +9,23 @@ export function FaqPage() {
                 <Card>
                     <CardContent>
                         <Box marginLeft={1} paddingY={2}>
-                            <Typography variant="h4">
+                            <Typography textAlign={'center'} variant="h1">
                                 Usein kysytyt kysymykset
                             </Typography>
-                            <Typography marginBottom={3}>
+                            <Typography
+                                marginTop={4}
+                                marginBottom={4}
+                                textAlign={'center'}
+                                variant="h2"
+                            >
                                 Täältä löydät vastauksia usein kysyttyihin
                                 kysymyksiin.
                             </Typography>
-                            <Typography variant="h6">
+                            <Typography
+                                variant="h3"
+                                marginBottom={1}
+                                fontWeight={'bold'}
+                            >
                                 Mikä on Ilmastokompassi?
                             </Typography>
                             <Typography marginBottom={2}>
@@ -28,7 +37,11 @@ export function FaqPage() {
                                 soveltuu myös muille ilmastonmuutoksesta
                                 kiinnostuneille.
                             </Typography>
-                            <Typography variant="h6">
+                            <Typography
+                                variant="h3"
+                                marginBottom={1}
+                                fontWeight={'bold'}
+                            >
                                 Miten voin navigoida sivustolla?
                             </Typography>
                             <Typography marginBottom={2}>
@@ -38,7 +51,11 @@ export function FaqPage() {
                                 osioon. Logo ja &quot;Ilmastokompassi&quot;
                                 vievät sivuston etusivulle.
                             </Typography>
-                            <Typography variant="h6">
+                            <Typography
+                                variant="h3"
+                                marginBottom={1}
+                                fontWeight={'bold'}
+                            >
                                 Mikä on Ilmastoroolikysely?
                             </Typography>
                             <Typography marginBottom={2}>
@@ -47,7 +64,11 @@ export function FaqPage() {
                                 Ilmastoroolikyselyyn vastaaminen onnistuu
                                 sivuston etusivulta.
                             </Typography>
-                            <Typography variant="h6">
+                            <Typography
+                                variant="h3"
+                                marginBottom={1}
+                                fontWeight={'bold'}
+                            >
                                 Mikä on Ilmastorooli?
                             </Typography>
                             <Typography marginBottom={2}>
@@ -58,7 +79,11 @@ export function FaqPage() {
                                 Kestävän elämäntavan etsijä tai Eettinen
                                 kuluttaja.
                             </Typography>
-                            <Typography variant="h6">
+                            <Typography
+                                variant="h3"
+                                marginBottom={1}
+                                fontWeight={'bold'}
+                            >
                                 Miten voin tehdä kyselyn?
                             </Typography>
                             <Typography marginBottom={2}>
@@ -67,13 +92,23 @@ export function FaqPage() {
                                 painiketta. Kysely alkaa painamalla
                                 &quot;ALOITA&quot; painiketta.
                             </Typography>
-                            <Typography variant="h6">Mikä on ryhmä?</Typography>
+                            <Typography
+                                variant="h3"
+                                marginBottom={1}
+                                fontWeight={'bold'}
+                            >
+                                Mikä on ryhmä?
+                            </Typography>
                             <Typography marginBottom={2}>
                                 Kyselyyn vastaaminen onnistuu myös ryhmänä,
                                 jolloin voitte vertailla kyselyn tuloksia
                                 keskenänne.
                             </Typography>
-                            <Typography variant="h6">
+                            <Typography
+                                variant="h3"
+                                marginBottom={1}
+                                fontWeight={'bold'}
+                            >
                                 Mistä tiedän olenko liittynyt ryhmään?
                             </Typography>
                             <Typography marginBottom={2}>
@@ -81,7 +116,11 @@ export function FaqPage() {
                                 ole osa ryhmää, ikonia painamalla pääset
                                 liittymään ryhmään.
                             </Typography>
-                            <Typography variant="h6">
+                            <Typography
+                                variant="h3"
+                                marginBottom={1}
+                                fontWeight={'bold'}
+                            >
                                 Miten voin liittyä ryhmään?
                             </Typography>
                             <Typography marginBottom={2}>
@@ -93,14 +132,22 @@ export function FaqPage() {
                                 &quot;LIITY&quot; painiketta. Ryhmätunnuksen
                                 saat ryhmän ylläpitäjältä.
                             </Typography>
-                            <Typography variant="h6">
+                            <Typography
+                                variant="h3"
+                                marginBottom={1}
+                                fontWeight={'bold'}
+                            >
                                 Miten voin luoda ryhmän?
                             </Typography>
                             <Typography marginBottom={2}>
                                 Ryhmän luominen onnistuu Ilmastoroolikyselyt-
                                 sivulta. Paina &quot;LUO RYHMÄ&quot; painiketta.
                             </Typography>
-                            <Typography variant="h6">
+                            <Typography
+                                variant="h3"
+                                marginBottom={1}
+                                fontWeight={'bold'}
+                            >
                                 Miten voin tarkastella ryhmän tuloksia?
                             </Typography>
                             <Typography marginBottom={2}>
@@ -109,7 +156,11 @@ export function FaqPage() {
                                 olevaa kuvaa ja &quot;Ryhmän tulokset&quot;
                                 painiketta.
                             </Typography>
-                            <Typography variant="h6">
+                            <Typography
+                                variant="h3"
+                                marginBottom={1}
+                                fontWeight={'bold'}
+                            >
                                 Miten voin poistua ryhmästä?
                             </Typography>
                             <Typography marginBottom={2}>

--- a/frontend/src/pages/LandingPage.jsx
+++ b/frontend/src/pages/LandingPage.jsx
@@ -36,16 +36,14 @@ export const LandingPage = () => {
                             variant="h1"
                             align="center"
                             fontWeight={700}
-                            sx={{ fontSize: ['1.5rem', '2.5rem', '3rem'] }}
                         >
                             Tervetuloa Ilmastokompassiin!
                         </Typography>
                         <Typography
-                            variant="h4"
+                            variant="h3"
                             component="div"
                             align="center"
                             fontWeight={700}
-                            sx={{ fontSize: ['1rem', '1.2rem', '1.5rem'] }}
                         >
                             Täällä pääset kartuttamaan ilmastotietämystäsi ja
                             ymmärtämään omaa suhtautumistasi ilmastonmuutokseen.

--- a/frontend/src/pages/RoleSurveyGroupSummaryPage.jsx
+++ b/frontend/src/pages/RoleSurveyGroupSummaryPage.jsx
@@ -87,7 +87,7 @@ export const RoleSurveyGroupSummaryPage = () => {
                         paddingY={4}
                         alignItems="center"
                     >
-                        <Typography variant="h4">
+                        <Typography variant="h1">
                             Ryhmän {groupToken} ilmastorooli
                         </Typography>
                         {isLoadingroles || isLoadingAllrolesData ? (
@@ -105,7 +105,7 @@ export const RoleSurveyGroupSummaryPage = () => {
                                 ) : (
                                     <>
                                         {highestScoreroles.length > 1 && (
-                                            <Typography variant="h5">
+                                            <Typography variant="h2">
                                                 Teillä on useita rooleja, jotka
                                                 kuvastavat ryhmäänne!
                                             </Typography>
@@ -117,7 +117,7 @@ export const RoleSurveyGroupSummaryPage = () => {
                                             />
                                         ))}
 
-                                        <Typography variant="h5">
+                                        <Typography variant="h2">
                                             Ryhmän {groupToken} jakauma.
                                             Kyselyyn on vastannut{' '}
                                             {allRolesData.response_amount}{' '}

--- a/frontend/src/pages/RoleSurveySummaryPage.jsx
+++ b/frontend/src/pages/RoleSurveySummaryPage.jsx
@@ -107,14 +107,14 @@ export const RoleSurveySummaryPage = () => {
                         paddingY={4}
                         alignItems="center"
                     >
-                        <Typography variant="h4">Ilmastoroolisi</Typography>
+                        <Typography variant="h1">Ilmastoroolisi</Typography>
                         {isLoadingRoles ||
                         isLoadingSummary ||
                         isLoadingAllRolesData ? (
                             <p>Loading...</p>
                         ) : filteredSummaryScores.length === 0 ? (
                             <>
-                                <Typography variant="h5">
+                                <Typography variant="h2">
                                     Ei tarpeeksi dataa tulosten näyttämiseen
                                 </Typography>
                                 <Button
@@ -127,7 +127,7 @@ export const RoleSurveySummaryPage = () => {
                             </>
                         ) : answerCount > 0 ? (
                             <>
-                                <Typography variant="h5">
+                                <Typography variant="h2" paddingBottom={2}>
                                     Olet vastannut {answerCount}/
                                     {totalQuestions} kysymykseen ja niiden
                                     perusteella sinun ilmastoroolisi
@@ -138,7 +138,7 @@ export const RoleSurveySummaryPage = () => {
                                     )}
                                     ...
                                 </Typography>
-                                <Stack spacing={2}>
+                                <Stack spacing={2} paddingBottom={4}>
                                     {highestScoreRoles.map((role) => (
                                         <SummaryRole
                                             key={role.id}
@@ -146,13 +146,13 @@ export const RoleSurveySummaryPage = () => {
                                         />
                                     ))}
                                 </Stack>
-                                <Typography variant="h5">
+                                <Typography variant="h2">
                                     Eri roolien välinen jakauma
                                 </Typography>
                                 <SummaryDoughnut data={doughnutChartData} />
                                 {groupToken && (
                                     <>
-                                        <Typography variant="h5">
+                                        <Typography variant="h2">
                                             Ryhmän {groupToken} jakauma.
                                             Kyselyyn on vastannut{' '}
                                             {allRolesData.response_amount}{' '}

--- a/frontend/src/theme.jsx
+++ b/frontend/src/theme.jsx
@@ -7,6 +7,25 @@ export const theme = responsiveFontSizes(
             button: {
                 textTransform: 'none',
             },
+            body1: {
+                fontSize: '1.4rem',
+            },
+            h1: {
+                fontSize: '3rem',
+                fontWeight: 'normal',
+            },
+            h2: {
+                fontSize: '1.8rem',
+                fontWeight: 'normal',
+            },
+            h3: {
+                fontSize: '1.4rem',
+                fontWeight: 'normal',
+            },
+            h4: {
+                fontSize: '1.2rem',
+                fontWeight: 'normal',
+            },
         },
         palette: {
             primary: {


### PR DESCRIPTION
Change the headings on most pages to new ones, so we don't have to use h4-h5. The font sizes are now larger, following the feedback received. 

The font sizes can be altered later if needed, these are the ones I found pleasant enough. The reviewer of this pull request can check the sizes locally if needed. Double checking that both desktop and mobile sizes look nice could be useful.

Contributes to #411