### PR TITLE
Group functions moved to accordion and layout improvements, updated cypress

### DIFF
--- a/frontend/cypress/e2e/groupCreation.cy.js
+++ b/frontend/cypress/e2e/groupCreation.cy.js
@@ -10,6 +10,7 @@ describe('Open group creation dialog', function () {
             },
             () => {
                 beforeEach(() => {
+                    cy.contains('Vastaa ryhmässä').click()
                     cy.findByTestId('open-create-group-dialog').click()
                     cy.findByTestId('create-group-dialog')
                         .as('groupDialog')

--- a/frontend/cypress/e2e/groupSummary.cy.js
+++ b/frontend/cypress/e2e/groupSummary.cy.js
@@ -12,6 +12,7 @@ describe('Group summary page', function () {
             },
             () => {
                 beforeEach(() => {
+                    cy.contains('Vastaa ryhmässä').click()
                     cy.findByTestId('group-token-input').as('groupTokenInput')
                     cy.findByTestId('join-group').as('joinGroup')
 

--- a/frontend/src/components/CreateGroupDialog.jsx
+++ b/frontend/src/components/CreateGroupDialog.jsx
@@ -7,6 +7,7 @@ import {
     DialogActions,
     TextField,
     Button,
+    Typography,
 } from '@mui/material'
 
 export default function CreateGroupDialog() {
@@ -69,7 +70,14 @@ export default function CreateGroupDialog() {
                 color="secondary"
                 onClick={() => setOpen(true)}
             >
-                Luo ryhmä
+                <Typography
+                    component="div"
+                    padding={0.5}
+                    letterSpacing={1}
+                    variant="button"
+                >
+                    LUO RYHMÄ
+                </Typography>
             </Button>
             <Dialog
                 data-testid="create-group-dialog"

--- a/frontend/src/components/GroupForm.jsx
+++ b/frontend/src/components/GroupForm.jsx
@@ -1,6 +1,7 @@
-import { Button, Stack, TextField, Snackbar } from '@mui/material'
+import { Button, Stack, TextField, Snackbar, Typography } from '@mui/material'
 import { useState } from 'react'
 import Alert from '@mui/material/Alert'
+import CreateGroupDialog from './CreateGroupDialog'
 
 const JoinGroupForm = () => {
     const [groupToken, setGroupToken] = useState('')
@@ -48,9 +49,9 @@ const JoinGroupForm = () => {
     return (
         <>
             <Stack
-                direction={{ xs: 'column', sm: 'row' }}
+                direction={{ xs: 'column', sm: 'column', md: 'row' }}
                 justifyContent="space-evenly"
-                alignItems="center"
+                alignItems={{ xs: 'center', sm: 'center', md: 'flex-start' }}
                 spacing={2}
             >
                 <TextField
@@ -64,14 +65,24 @@ const JoinGroupForm = () => {
                     size="small"
                     onKeyDown={handleKeyDown}
                 />
-                <Button
-                    data-testid="join-group"
-                    onClick={handleSubmit}
-                    color="secondary"
-                    variant="contained"
-                >
-                    Liity ryhmään
-                </Button>
+                <Stack direction={'row'} spacing={3}>
+                    <Button
+                        data-testid="join-group"
+                        onClick={handleSubmit}
+                        color="secondary"
+                        variant="contained"
+                    >
+                        <Typography
+                            component="div"
+                            padding={0.5}
+                            letterSpacing={1}
+                            variant="button"
+                        >
+                            LIITY
+                        </Typography>
+                    </Button>
+                    <CreateGroupDialog />
+                </Stack>
             </Stack>
             <Snackbar
                 open={open}

--- a/frontend/src/components/roleSurvey/GroupAccordion.jsx
+++ b/frontend/src/components/roleSurvey/GroupAccordion.jsx
@@ -1,0 +1,61 @@
+import {
+    Accordion,
+    AccordionDetails,
+    AccordionSummary,
+    Typography,
+    Box,
+    Stack,
+} from '@mui/material'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import GroupForm from '../GroupForm'
+
+const GroupAccordion = () => {
+    return (
+        <Accordion>
+            <AccordionSummary
+                expandIcon={<ExpandMoreIcon />}
+                aria-controls="panel-1-content"
+                id="panel-1-content"
+            >
+                <Typography align="center" fontWeight={500}>
+                    Vastaa ryhmässä
+                </Typography>
+            </AccordionSummary>
+            <AccordionDetails>
+                <Stack
+                    alignItems="center"
+                    spacing={4}
+                    padding={{ xs: 0, md: 4 }}
+                >
+                    <Box>
+                        <Typography>
+                            Ilmastoroolikyselyn voi tehdä ryhmässä. Jokainen
+                            vastaaja saa oman roolin ja näkee anonyymin
+                            yhteenvedon ryhmässä esiintyneistä rooleista. Ryhmän
+                            tulokset tulevat näkyviin, kun vähintään viisi
+                            ryhmän jäsentä on vastannut kyselyyn. Ryhmän
+                            yhteisiä tuloksia pääset tarkastelemaan myös
+                            sivuston oikean yläkulman painikkeesta.
+                        </Typography>
+
+                        <Typography paddingTop={2}>
+                            Mikäli teillä ei ole vielä valmiiksi luotua ryhmää,
+                            voit tehdä sen painamalla &quot;Luo ryhmä&quot;
+                            painiketta.
+                        </Typography>
+                    </Box>
+                    <Stack
+                        direction={{ xs: 'column', sm: 'row' }}
+                        justifyContent="space-evenly"
+                        alignItems="center"
+                        spacing={2}
+                    >
+                        <GroupForm />
+                    </Stack>
+                </Stack>
+            </AccordionDetails>
+        </Accordion>
+    )
+}
+
+export default GroupAccordion

--- a/frontend/src/pages/RoleSurveyPage.jsx
+++ b/frontend/src/pages/RoleSurveyPage.jsx
@@ -10,10 +10,9 @@ import {
 } from '@mui/material'
 
 import { useTitle } from '../hooks/useTitle'
-import JoinGroupForm from '../components/JoinGroupForm'
 import RoleAccordion from '../components/roleSurvey/RoleAccordion'
-import CreateGroupDialog from '../components/CreateGroupDialog'
 import RoleSurveyLogo from '../assets/roolilogo.png'
+import GroupAccordion from '../components/roleSurvey/GroupAccordion'
 import useSWR from 'swr'
 
 export function RoleSurveyPage() {
@@ -55,21 +54,10 @@ export function RoleSurveyPage() {
                             >
                                 Ilmastoroolikysely
                             </Typography>
-
-                            <Box>
-                                <Typography align="center">
-                                    Testaa, minkälainen ilmastoroolihahmo
-                                    kuvastaa juuri sinua. Koeta vastata
-                                    mahdollisimman rehellisesti ja omana
-                                    itsenäsi. Näin saat parhaan kuvauksen juuri
-                                    sinulle sopivasta hahmosta. Pääset kyselyyn
-                                    painamalla &quot;Aloita&quot; painiketta.
-                                    Kun olet vastannut kysymyksiin, saat
-                                    selville, mikä ilmastoroolihahmo kuvastaa
-                                    sinua parhaiten. Voit tutustua hahmoihin
-                                    lyhyesti alta.
-                                </Typography>
-                            </Box>
+                            <Typography align="center">
+                                Testaa, minkälainen ilmastoroolihahmo kuvastaa
+                                juuri sinua!
+                            </Typography>
                             <Box
                                 component="img"
                                 src={RoleSurveyLogo}
@@ -78,50 +66,36 @@ export function RoleSurveyPage() {
                                 borderRadius={2}
                                 boxShadow={5}
                             />
-                            <Typography
-                                variant="h2"
-                                sx={{ fontSize: ['1.5rem', '1.8rem', '2rem'] }}
-                                align="center"
-                            >
-                                Vastaaminen ryhmässä
-                            </Typography>
+
                             <Box>
                                 <Typography align="center">
-                                    Ilmastoroolikyselyn voi tehdä myös ryhmässä.
-                                    Jokainen vastaaja saa oman roolin ja näkee
-                                    anonyymin yhteenvedon ryhmässä esiintyneistä
-                                    rooleista. Ryhmän tulokset tulevat näkyviin,
-                                    kun vähintään viisi ryhmän jäsentä on
-                                    vastannut kyselyyn. Ryhmän yhteisiä tuloksia
-                                    pääset tarkastelemaan myös sivuston oikean
-                                    yläkulman painikkeesta. Mikäli teillä ei ole
-                                    vielä valmiiksi luotua ryhmää, voit tehdä
-                                    sen painamalla &quot;Luo ryhmä&quot;
-                                    painiketta.
+                                    Koeta vastata mahdollisimman rehellisesti ja
+                                    omana itsenäsi. Näin saat parhaan kuvauksen
+                                    juuri sinulle sopivasta hahmosta. Pääset
+                                    kyselyyn painamalla &quot;Aloita&quot;
+                                    painiketta. Kun olet vastannut kysymyksiin,
+                                    saat selville, mikä ilmastoroolihahmo
+                                    kuvastaa sinua parhaiten.
                                 </Typography>
                             </Box>
-                            <Stack alignItems="center" spacing={2} padding={3}>
-                                <JoinGroupForm />
-                                <CreateGroupDialog />
-                                <Button
-                                    sx={{
-                                        width: 200,
-                                        height: 60,
-                                    }}
-                                    data-testid="start-survey"
-                                    variant="contained"
-                                    href="/kysymys/1"
-                                    color="secondary"
+                            <GroupAccordion />
+                            <Button
+                                size="large"
+                                data-testid="start-survey"
+                                variant="contained"
+                                href="/kysymys/1"
+                                color="secondary"
+                            >
+                                <Typography
+                                    paddingY={2}
+                                    paddingX={4}
+                                    variant="h2"
+                                    component="div"
+                                    letterSpacing={2}
                                 >
-                                    <Typography
-                                        variant="h5"
-                                        component="div"
-                                        letterSpacing={2}
-                                    >
-                                        Aloita
-                                    </Typography>
-                                </Button>
-                            </Stack>
+                                    ALOITA
+                                </Typography>
+                            </Button>
                         </Stack>
                     </CardContent>
                 </Card>


### PR DESCRIPTION
- Accordion with all group functions for the role survey on the page
- Layout inside accordion improved: liity moved next to luo ryhmä, and they stay in a row also on a small screen beneath the text field
- Cohesive look on buttons: luo ryhmä, liity, and aloita
- Renamed components to match better the new structure
- Updated cypress tests

closes #511 