### PR TITLE
Refactor API error handling

### DIFF
--- a/backend/src/api.py
+++ b/backend/src/api.py
@@ -1,5 +1,5 @@
-from flask import Blueprint
-
+from flask import Blueprint, jsonify
+from werkzeug.exceptions import HTTPException, InternalServerError
 from src.routes.survey_routes import survey_routes
 from src.routes.group_routes import group_routes
 from src.routes.quiz_routes import quiz_routes
@@ -14,3 +14,21 @@ api.register_blueprint(quiz_routes)
 @api.get("/ping")
 def ping():
     return "pong"
+
+
+@api.errorhandler(Exception)
+def handle_exception(exception):
+    if isinstance(exception, HTTPException):
+        return exception
+
+    return handle_http_exception(InternalServerError())
+
+
+@api.errorhandler(HTTPException)
+def handle_http_exception(exception):
+    """Return JSON instead of HTML for HTTP errors."""
+    return jsonify({
+        "code": exception.code,
+        "name": exception.name,
+        "description": exception.description,
+    }), exception.code

--- a/backend/src/routes/quiz_routes.py
+++ b/backend/src/routes/quiz_routes.py
@@ -8,28 +8,20 @@ quiz_routes = Blueprint('quiz', __name__, url_prefix='/quiz')
 def create_new_quiz_response():
     data = request.get_json()
     group_token = data.get("groupToken")
-    try:
-        response_id = default_quiz_service.create_quiz_response(group_token)
-        return jsonify(response_id=response_id)
-    except Exception:  # pylint: disable=broad-except
-        return jsonify(error="Could not create response_id"), 500
+
+    response_id = default_quiz_service.create_quiz_response(group_token)
+    return jsonify(response_id=response_id)
 
 
 @quiz_routes.get("/questions")
 def get_quiz_questions():
-    try:
-        return jsonify(default_quiz_service.get_questions())
-    except Exception:  # pylint: disable=broad-except
-        return jsonify(error="Could not get questions"), 500
+    return jsonify(default_quiz_service.get_questions())
 
 
 @quiz_routes.get("/answers/<string:question_id>")
 def get_correct_answers(question_id):
-    try:
-        correct_answers = default_quiz_service.get_correct_answers(question_id)
-        return jsonify(correct_answers=correct_answers)
-    except Exception:  # pylint: disable=broad-except
-        return jsonify("Could not fetch correct answers"), 500
+    correct_answers = default_quiz_service.get_correct_answers(question_id)
+    return jsonify(correct_answers=correct_answers)
 
 
 @quiz_routes.post("/save")
@@ -38,20 +30,16 @@ def save_quiz_answer():
     answer = data.get("answer")
     response_id = data.get("responseId")
     question_id = data.get("questionId")
-    try:
-        default_quiz_service.save_answers(
-            question_id, answer, response_id)
-        correct_answers = default_quiz_service.get_correct_answers(question_id)
-        info_text = default_quiz_service.get_info_text(question_id)
-        return jsonify(correct_answers=correct_answers, info_text=info_text)
-    except Exception:  # pylint: disable=broad-except
-        return jsonify("error"), 500
+
+    default_quiz_service.save_answers(question_id, answer, response_id)
+
+    correct_answers = default_quiz_service.get_correct_answers(question_id)
+    info_text = default_quiz_service.get_info_text(question_id)
+
+    return jsonify(correct_answers=correct_answers, info_text=info_text)
 
 
 @quiz_routes.get("/summary")
 def get_quiz_summary():
-    try:
-        summary = default_quiz_service.get_all_questions_and_answers()
-        return jsonify(summary)
-    except Exception:  # pylint: disable=broad-except
-        return jsonify(error="Could not get summary"), 500
+    summary = default_quiz_service.get_all_questions_and_answers()
+    return jsonify(summary)

--- a/backend/src/routes/survey_routes.py
+++ b/backend/src/routes/survey_routes.py
@@ -1,4 +1,5 @@
-from flask import Blueprint, jsonify, abort, request
+from flask import Blueprint, jsonify, request
+from werkzeug.exceptions import NotFound
 from src.services.profile_service import default_profile_service
 from src.services.survey_service import default_survey_service
 from src.services.group_service import default_group_service
@@ -8,34 +9,22 @@ survey_routes = Blueprint('roleSurvey', __name__, url_prefix='/survey')
 
 @survey_routes.get("/roles")
 def roles():
-    try:
-        return jsonify(default_profile_service.get_profiles())
-
-    except Exception:  # pylint: disable=broad-except
-        return jsonify(error="Something went wrong!"), 500
+    return jsonify(default_profile_service.get_profiles())
 
 
 @survey_routes.get("/questions")
 def total_questions():
-    try:
-        return jsonify(default_survey_service.get_questions())
-
-    except Exception:  # pylint: disable=broad-except
-        return jsonify(error="Something went wrong!"), 500
+    return jsonify(default_survey_service.get_questions())
 
 
 @survey_routes.get("/questions/<int:question_id>")
 def get_question(question_id):
-    try:
-        questions_list = default_survey_service.get_questions()
-        question = next(
-            (q for q in questions_list if q['id'] == question_id), None)
-        if question is None:
-            abort(404, description="Question not found")
-        return jsonify(question)
-
-    except Exception:  # pylint: disable=broad-except
-        return jsonify(error="Something went wrong!"), 500
+    questions_list = default_survey_service.get_questions()
+    question = next(
+        (q for q in questions_list if q['id'] == question_id), None)
+    if question is None:
+        raise NotFound("Question not found")
+    return jsonify(question)
 
 
 @survey_routes.post("/submit")
@@ -44,24 +33,16 @@ def submit():
     responses = data.get('responses')
     group_token = data.get('groupToken')
 
-    try:
-        response_id = default_survey_service.save_answers(responses)
-        if group_token:
-            default_group_service.insert_group_token_to_responses(
-                group_token, response_id)
-        return jsonify({"status": "success",
-                        "message": "Answers submitted successfully",
-                        "user_id": response_id})
-    except Exception:  # pylint: disable=broad-except
-        return jsonify({"status": "fail",
-                        "message": "Something went wrong"}), 500
+    response_id = default_survey_service.save_answers(responses)
+    if group_token:
+        default_group_service.insert_group_token_to_responses(
+            group_token, response_id)
+
+    return jsonify({"user_id": response_id})
 
 
 @survey_routes.get('/summary/<int:response_id>')
 def get_summary(response_id):
-    try:
-        summary, count, total_questions_count = default_survey_service.get_summary(
-            response_id)
-        return jsonify(count=count, summary=summary, total_questions_count=total_questions_count)
-    except Exception:  # pylint: disable=broad-except
-        return jsonify(error="Something went wrong!"), 500
+    summary, count, total_questions_count = default_survey_service.get_summary(
+        response_id)
+    return jsonify(count=count, summary=summary, total_questions_count=total_questions_count)

--- a/backend/src/services/group_service.py
+++ b/backend/src/services/group_service.py
@@ -1,5 +1,6 @@
 from src.repositories.group_repository import default_group_repository
 
+
 class GroupService:
     # pylint: disable=too-few-public-methods
 
@@ -11,8 +12,6 @@ class GroupService:
             self.group_repository.save_group(token)
         except Exception as error:  # pylint: disable=broad-except
             raise error
-
-        return token
 
     def check_if_group_exists(self, token):
         try:

--- a/backend/src/services/group_service.py
+++ b/backend/src/services/group_service.py
@@ -8,17 +8,11 @@ class GroupService:
         self.group_repository = group_repository
 
     def save_group(self, token):
-        try:
-            self.group_repository.save_group(token)
-        except Exception as error:  # pylint: disable=broad-except
-            raise error
+        self.group_repository.save_group(token)
 
     def check_if_group_exists(self, token):
-        try:
-            result = self.group_repository.check_if_group_exists(token)
-            return result
-        except Exception as error:
-            raise error
+        result = self.group_repository.check_if_group_exists(token)
+        return result
 
     def is_group_name_valid(self, token):
         if token == '':
@@ -30,22 +24,15 @@ class GroupService:
         return True
 
     def insert_group_token_to_responses(self, token, response_id):
-        try:
-            self.group_repository.insert_group_token_to_responses(
-                token, response_id)
-        except Exception as error:
-            raise error
+        self.group_repository.insert_group_token_to_responses(
+            token, response_id)
 
     def fetch_scores_by_group(self, token):
-        try:
-            scores = self.group_repository.fetch_scores_by_group(token)
+        scores = self.group_repository.fetch_scores_by_group(token)
 
-            final_score, response_amount = self._list_to_dict_and_response_amount(
-                scores)
-            return final_score, response_amount
-
-        except Exception as error:
-            raise error
+        final_score, response_amount = self._list_to_dict_and_response_amount(
+            scores)
+        return final_score, response_amount
 
     def _list_to_dict_and_response_amount(self, scores):
         # Turn score from list of tuples into dict

--- a/backend/src/services/quiz_service.py
+++ b/backend/src/services/quiz_service.py
@@ -30,61 +30,43 @@ class QuizService:
             raise error
 
     def create_quiz_response(self, group_token=None):
-        try:
-            return self.quiz_repository.create_quiz_response(group_token)
-        except Exception as error:
-            raise error
+        return self.quiz_repository.create_quiz_response(group_token)
 
     def save_answers(self, question_id, answers, response_id):
-        try:
-            self.quiz_repository.save_answers(
-                question_id, answers, response_id)
-        except Exception as error:
-            raise error
+        self.quiz_repository.save_answers(
+            question_id, answers, response_id)
 
         return response_id
 
     def get_response_answers(self, response_id):
-        try:
-            return self.quiz_repository.get_response_answers(response_id)
-        except Exception as error:
-            raise error
+        return self.quiz_repository.get_response_answers(response_id)
 
     def get_correct_answers(self, question_id):
-        try:
-            return self.quiz_repository.get_correct_answers(question_id)
-        except Exception as error:
-            raise error
+        return self.quiz_repository.get_correct_answers(question_id)
 
     def get_info_text(self, question_id):
-        try:
-            return self.quiz_repository.get_info_text(question_id)
-        except Exception as error:
-            raise error
+        return self.quiz_repository.get_info_text(question_id)
 
     def get_all_questions_and_answers(self):
-        try:
-            results = self.quiz_repository.get_all_questions_and_answers()
+        results = self.quiz_repository.get_all_questions_and_answers()
 
-            summary = {}
-            for question_text, info_text, correct_answer in results:
-                if question_text not in summary:
-                    summary[question_text] = {
-                        "correct_answers": [], "info_text": info_text}
-                summary[question_text]["correct_answers"].append(
-                    correct_answer)
+        summary = {}
+        for question_text, info_text, correct_answer in results:
+            if question_text not in summary:
+                summary[question_text] = {
+                    "correct_answers": [], "info_text": info_text}
+            summary[question_text]["correct_answers"].append(
+                correct_answer)
 
-            summary_list = [
-                {
-                    'question_text': k,
-                    'correct_answers': v["correct_answers"],
-                    "info_text": v["info_text"]
-                }
-                for k, v in summary.items()]
+        summary_list = [
+            {
+                'question_text': k,
+                'correct_answers': v["correct_answers"],
+                "info_text": v["info_text"]
+            }
+            for k, v in summary.items()]
 
-            return summary_list
-        except Exception as error:
-            raise error
+        return summary_list
 
 
 default_quiz_service = QuizService(default_quiz_repository)

--- a/backend/src/services/survey_service.py
+++ b/backend/src/services/survey_service.py
@@ -20,25 +20,18 @@ class SurveyService:
 
     def save_answers(self, answers):
         answers_with_scores = {}
-        try:
-            for question_id, answer in answers.items():
-                answers_with_scores[question_id] = SCORES[answer]
+        for question_id, answer in answers.items():
+            answers_with_scores[question_id] = SCORES[answer]
 
-            response_id = self.survey_repository.save_answers(
-                answers_with_scores)
-        except Exception as error:
-            raise error
+        response_id = self.survey_repository.save_answers(answers_with_scores)
 
         return response_id
 
     def get_climate_percentages(self, response_id):
-        try:
-            score_profile = self.survey_repository.get_response_answers(
-                response_id)
-        except Exception as error:
-            raise error
-
         total_scores = {}
+
+        score_profile = self.survey_repository.get_response_answers(
+            response_id)
 
         for score, profile_id in score_profile:
             if profile_id not in total_scores:
@@ -46,7 +39,6 @@ class SurveyService:
             else:
                 total_scores[profile_id] += score
 
-        print(total_scores)
         return total_scores
 
     def get_summary(self, response_id):

--- a/backend/src/tests/test_group_routes.py
+++ b/backend/src/tests/test_group_routes.py
@@ -3,43 +3,36 @@ import json
 
 def test_new_group(client):
     group_token = "FOOBAR1"
-    response = client.post('/api/groups/new', json={'token': group_token})
+    response = client.post(
+        '/api/groups/new', json={'groupToken': group_token})
     result = json.loads(response.data)
 
-    assert response.status_code == 200
-    assert result['status'] == 'success'
+    assert response.status_code == 201
+    assert result['group_token'] == group_token
 
 
-def test_group_get_survey_summary(client):
-    group_token = 'FOOBAR2'
-    response = client.post('/api/groups/new', json={'token': group_token})
-    response = client.get(f'/api/groups/{group_token}/survey/summary')
+def test_new_group_already_exists(client):
+    group_token = "FOOBAR1"
+
+    client.post('/api/groups/new', json={'groupToken': group_token})
+    response = client.post(
+        '/api/groups/new', json={'groupToken': group_token})
     result = json.loads(response.data)
 
-    assert response.status_code == 200
-    assert result['status'] == 'success'
-    assert result['message'] == 'Group exists'
-
-
-def test_nonexisting_group_summary(client):
-    group_token = 'NOGROUP'
-    response = client.get(f'/api/groups/{group_token}/survey/summary')
-    result = json.loads(response.data)
-
-    assert response.status_code == 400
-    assert result['status'] == 'fail'
-    assert result['message'] == 'Group does not exist'
+    assert response.status_code == 409
+    assert result['description'] == "Group already exists"
 
 
 def test_get_group(client):
     group_token = 'FOOBAR3'
-    response = client.post('/api/groups/new', json={'token': group_token})
+    response = client.post(
+        '/api/groups/new', json={'groupToken': group_token})
 
     response = client.get('/api/groups/' + group_token)
     result = json.loads(response.data)
 
     assert response.status_code == 200
-    assert result == {'group_token': True}
+    assert result['group_token'] == group_token
 
 
 def test_get_nonexisting_group(client):
@@ -47,13 +40,14 @@ def test_get_nonexisting_group(client):
     response = client.get('/api/groups/' + group_token)
     result = json.loads(response.data)
 
-    assert response.status_code == 200
-    assert result == {'group_token': False}
+    assert response.status_code == 404
+    assert result['description'] == 'Group not found'
 
 
 def test_get_group_score(client):
     group_token = 'FOOBAR4'
-    response = client.post('/api/groups/new', json={'token': group_token})
+    response = client.post(
+        '/api/groups/new', json={'groupToken': group_token})
 
     data = {"responses": {"1": 1, "2": 2, "3": 3}, "groupToken": group_token}
     response = client.post('/api/survey/submit', json=data)
@@ -71,6 +65,5 @@ def test_get_nonexisting_group_score(client):
     response = client.get(f'/api/groups/{group_token}/score')
     result = json.loads(response.data)
 
-    assert response.status_code == 400
-    assert result['status'] == 'fail'
-    assert result['message'] == 'Group does not exist'
+    assert response.status_code == 404
+    assert result['description'] == 'Group not found'

--- a/backend/src/tests/test_quiz_routes.py
+++ b/backend/src/tests/test_quiz_routes.py
@@ -3,7 +3,8 @@ import json
 
 def test_create_new_quiz_response_with_group_token(client):
     group_token = "FOOBAR5"
-    response = client.post('/api/groups/new', json={'token': group_token})
+    response = client.post(
+        '/api/groups/new', json={'groupToken': group_token})
     response = client.post('/api/quiz/new', json={"groupToken": group_token})
     result = json.loads(response.data)
 
@@ -31,7 +32,7 @@ def test_get_quiz_questions(client):
 
 def test_save_quiz_answer(client):
     group_token = "FOOBAR6"
-    response = client.post('/api/groups/new', json={'token': group_token})
+    response = client.post('/api/groups/new', json={'groupToken': group_token})
 
     response = client.post('/api/quiz/new', json={"groupToken": group_token})
     result = json.loads(response.data)

--- a/backend/src/tests/test_survey_routes.py
+++ b/backend/src/tests/test_survey_routes.py
@@ -34,8 +34,10 @@ def test_get_question(client):
 
 def test_get_question_not_found(client):
     response = client.get('/api/survey/questions/420')
+    result = json.loads(response.data)
 
-    assert response.status_code == 500
+    assert response.status_code == 404
+    assert result['description'] == 'Question not found'
 
 
 def test_submit(client):
@@ -50,7 +52,7 @@ def test_submit(client):
 
 def test_submit_with_group(client):
     group_token = 'FOOBAR7'
-    response = client.post('/api/groups/new', json={'token': group_token})
+    response = client.post('/api/groups/new', json={'groupToken': group_token})
 
     data = {"responses": {"1": 1, "2": 2, "3": 3}, "groupToken": group_token}
     response = client.post('/api/survey/submit', json=data)

--- a/frontend/cypress/e2e/groupJoining.cy.js
+++ b/frontend/cypress/e2e/groupJoining.cy.js
@@ -11,9 +11,14 @@ describe('Joining group', function () {
             () => {
                 beforeEach(() => {
                     cy.findByTestId('group-token-input').as('groupTokenInput')
+                    cy.findByTestId('join-group-accordion').as(
+                        'joinGroupAccordion'
+                    )
                     cy.findByTestId('join-group').as('joinGroup')
 
                     cy.exec('../bin/db-reset')
+
+                    cy.get('@joinGroupAccordion').click()
                 })
 
                 it('with empty token fails', function () {

--- a/frontend/cypress/support/commands.js
+++ b/frontend/cypress/support/commands.js
@@ -15,10 +15,10 @@ Cypress.Commands.add(
 )
 
 Cypress.Commands.add('createGroupWithApi', (groupToken) => {
-    cy.request('POST', '/api/groups/new', { token: groupToken }).then(
+    cy.request('POST', '/api/groups/new', { groupToken: groupToken }).then(
         (response) => {
+            expect(response.status).equals(201)
             expect(response.body).to.have.property('group_token', groupToken)
-            expect(response.body).to.have.property('status', 'success')
         }
     )
 })
@@ -28,13 +28,13 @@ Cypress.Commands.add('answerRoleSurveyWithApi', (groupToken, responses) => {
         groupToken: groupToken,
         responses: responses,
     }).then((response) => {
-        expect(response.body).to.have.property('status', 'success')
+        expect(response.status).equals(200)
     })
 })
 
 Cypress.Commands.add('joinGroup', (groupToken) => {
     cy.request('/api/groups/' + groupToken).then((response) => {
-        expect(response.body).to.have.property('group_token', true)
+        expect(response.body).to.have.property('group_token', groupToken)
 
         window.localStorage.setItem('groupToken', groupToken)
     })

--- a/frontend/src/components/CreateGroupDialog.jsx
+++ b/frontend/src/components/CreateGroupDialog.jsx
@@ -38,17 +38,15 @@ export default function CreateGroupDialog() {
             headers: {
                 'Content-Type': 'application/json',
             },
-            body: JSON.stringify({ token: groupName.toUpperCase() }),
+            body: JSON.stringify({ groupToken: groupName.toUpperCase() }),
+        }).then((response) => {
+            if (response.status !== 201) {
+                setIsValid(false)
+                setAlertMessage('Ryhmätunnus on jo käytössä.')
+                return
+            }
+            setGroupIsMade(true)
         })
-            .then((response) => response.json())
-            .then((data) => {
-                if (data.message === 'Group already exists') {
-                    setIsValid(false)
-                    setAlertMessage('Ryhmätunnus on jo käytössä.')
-                    return
-                }
-                setGroupIsMade(true)
-            })
     }
 
     const resetDialog = () => {

--- a/frontend/src/components/roleSurvey/GroupAccordion.jsx
+++ b/frontend/src/components/roleSurvey/GroupAccordion.jsx
@@ -15,7 +15,7 @@ const GroupAccordion = () => {
             <AccordionSummary
                 expandIcon={<ExpandMoreIcon />}
                 aria-controls="panel-1-content"
-                id="panel-1-content"
+                data-testid="join-group-accordion"
             >
                 <Typography align="center" fontWeight={500}>
                     Vastaa ryhmässä


### PR DESCRIPTION
* Use [generic error handling](https://flask.palletsprojects.com/en/3.0.x/errorhandling/#generic-exception-handlers) in the API
* Remove incorrectly named and unused `/groups/{groupToken}/survey/summary` endpoint
* Simplify exception raising logic and utilize HTTP status codes better
* Fix group joining cypress tests